### PR TITLE
private_place_guess in the rails app means place_guess can be public

### DIFF
--- a/lib/models/observation.js
+++ b/lib/models/observation.js
@@ -32,9 +32,6 @@ var Observation = class Observation extends Model {
          this.user.id === options.session.user_id ) {
       // logged in
     } else {
-      if( this.obscured ) {
-        delete this.place_guess;
-      }
       delete this.private_location;
       delete this.private_geojson;
     }

--- a/lib/models/observation.js
+++ b/lib/models/observation.js
@@ -14,9 +14,6 @@ var Observation = class Observation extends Model {
   constructor( attrs ) {
     super( attrs );
     this.obscured = !!(this.geoprivacy === "obscured" || this.private_location);
-    if( this.obscured ) {
-      delete this.place_guess
-    }
     delete this.private_location;
     delete this.private_geojson;
   }

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -78,15 +78,6 @@ describe( "Observations", function( ) {
       }).expect( 200, done );
     });
 
-    it( "strips place guess from obscured observations", function( done ) {
-      request( app ).get( "/v1/observations?geoprivacy=obscured_private" ).
-      expect( function( res ) {
-        expect( res.body.total_results ).to.eq( 1 );
-        expect( res.body.results[ 0 ].id ).to.eq( 333 );
-        expect( res.body.results[ 0 ].place_guess ).to.be.undefined;
-      }).expect( 200, done );
-    });
-
     it( "return iconic taxon names", function( done ) {
       request( app ).get( "/v1/observations?id=1" ).
       expect( function( res ) {

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -111,6 +111,15 @@ describe( "Observations", function( ) {
       }).expect( 200, done );
     });
 
+    it( "does not strips place guess from obscured observations", function( done ) {
+      request( app ).get( "/v1/observations?geoprivacy=obscured_private" ).
+      expect( function( res ) {
+        expect( res.body.total_results ).to.eq( 1 );
+        expect( res.body.results[ 0 ].id ).to.eq( 333 );
+        expect( res.body.results[ 0 ].place_guess ).to.eq( "Idaho" );
+      }).expect( 200, done );
+    });
+
     it( "filters by sounds", function( done ) {
       request( app ).get( "/v1/observations?sounds=true" ).
       expect( function( res ) {


### PR DESCRIPTION
Pretty simple, but I think it needs a full reindex of observations before it can be integrated, so the new, potentially obscured `place_guess` values can get into the ES index. 