### PR TITLE
Search by lack of annotation

### DIFF
--- a/lib/controllers/v1/controlled_terms_controller.js
+++ b/lib/controllers/v1/controlled_terms_controller.js
@@ -34,6 +34,29 @@ var ControlledTermsController = class ControlledTermsController {
     });
   }
 
+  static search( req, callback ) {
+    var query = { filters: [
+      { term: { is_value: false } }
+    ] };
+    ESModel.elasticResults( req, query, "controlled_terms", { }, ( err, data ) => {
+      if( err ) { return callback( err ); }
+      var terms = _.map( data.hits.hits, h => {
+        var term = new ControlledTerm( h._source );
+        if ( term.values ) {
+          term.values = term.values.map( v => ( new ControlledTerm( v ) ) );
+        }
+        return term;
+      });
+      if( err ) { return callback( err ); }
+      callback( null, {
+        total_results: data.hits.total,
+        page: Number( req.elastic_query.page ),
+        per_page: Number( req.elastic_query.per_page ),
+        results: terms
+      });
+    });
+  }
+
 };
 
 module.exports = ControlledTermsController;

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -582,6 +582,21 @@ ObservationsController.reqToElasticQueryComponents = function( req, callback ) {
         term: { "annotations.controlled_value_id": params.term_value_id } });
     }
     search_filters.push( nested_query );
+    if ( params.without_term_value_id ) {
+      inverse_filters.push( {
+        nested: {
+          path: "annotations",
+          query: {
+            bool: {
+              filter: [
+                { term: { "annotations.controlled_attribute_id": params.term_id } },
+                { term: { "annotations.controlled_value_id": params.without_term_value_id } }
+              ]
+            }
+          }
+        }
+      } );
+    }
   } else if( params.annotation_min_score || params.annotation_min_score === 0 ) {
     nested_query = {
       nested: {
@@ -592,6 +607,16 @@ ObservationsController.reqToElasticQueryComponents = function( req, callback ) {
       }
     }
     search_filters.push( nested_query );
+  } else if( params.without_term_id ) {
+    nested_query = {
+      nested: {
+        path: "annotations",
+        query: { bool: { filter: [
+          { term: { "annotations.controlled_attribute_id": params.without_term_id } }
+        ] } }
+      }
+    }
+    inverse_filters.push( nested_query );
   }
 
   // the default "extended" qs query parser for express is great

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -230,6 +230,7 @@ InaturalistAPI.server = function( ) {
   dfault( "get", "/v1/users/:id", UsersController.show );
   dfault( "get", "/v1/posts/for_user", PostsController.for_user );
   dfault( "post", "/v1/subscriptions/Observation/:id/subscribe", ObservationsController.subscribe );
+  dfault( "get", "/v1/controlled_terms", ControlledTermsController.search );
   dfault( "get", "/v1/controlled_terms/for_taxon", ControlledTermsController.forTaxon );
   dfault( "post", "/v1/annotations", AnnotationsController.create );
   dfault( "delete", "/v1/annotations/:id", AnnotationsController.delete );

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -240,6 +240,58 @@
           "geoprivacy": "private",
           "private_location": "1.234,1.234",
           "private_geojson": { "type": "Point", "coordinates": [ "1.234", "1.234" ] }
+        },
+        {
+          "id": 7,
+          "user": { "id": 5 },
+          "created_at": "2001-06-01T01:00:00",
+          "annotations": [
+            {
+              "controlled_attribute_id": 1,
+              "controlled_value_id": 1,
+              "concatenated_attr_val": "1|1",
+              "vote_score": 1.0,
+              "user_id": 5,
+              "votes": []
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "user": { "id": 5 },
+          "created_at": "2001-06-01T01:00:00",
+          "annotations": [
+            {
+              "controlled_attribute_id": 1,
+              "controlled_value_id": 2,
+              "concatenated_attr_val": "1|2",
+              "vote_score": 1.0,
+              "user_id": 5,
+              "votes": []
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "user": { "id": 5 },
+          "created_at": "2001-06-01T01:00:00",
+          "annotations": [
+            {
+              "controlled_attribute_id": 1,
+              "controlled_value_id": 2,
+              "concatenated_attr_val": "1|2",
+              "vote_score": -1,
+              "user_id": 5,
+              "votes": [
+                {
+                  "vote_flag": false,
+                  "user": {
+                    "id": 5
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/schema/indices/controlled_terms.js
+++ b/schema/indices/controlled_terms.js
@@ -1,0 +1,93 @@
+{
+  "controlled_term": {
+    "dynamic": "true",
+    "properties": {
+      "id": {
+        "type": "integer"
+      },
+      "is_value": {
+        "type": "boolean"
+      },
+      "labels": {
+        "properties": {
+          "definition": {
+            "analyzer": "ascii_snowball_analyzer",
+            "type": "text"
+          },
+          "id": {
+            "type": "long"
+          },
+          "label": {
+            "analyzer": "ascii_snowball_analyzer",
+            "type": "text"
+          },
+          "locale": {
+            "type": "keyword"
+          },
+          "valid_within_clade": {
+            "type": "long"
+          }
+        }
+      },
+      "multivalued": {
+        "type": "boolean"
+      },
+      "ontology_uri": {
+        "index": false,
+        "type": "keyword"
+      },
+      "uri": {
+        "index": false,
+        "type": "keyword"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "valid_within_clade": {
+        "type": "long"
+      },
+      "values": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "labels": {
+            "properties": {
+              "definition": {
+                "analyzer": "ascii_snowball_analyzer",
+                "type": "text"
+              },
+              "id": {
+                "type": "long"
+              },
+              "label": {
+                "analyzer": "ascii_snowball_analyzer",
+                "type": "text"
+              },
+              "locale": {
+                "type": "keyword"
+              },
+              "valid_within_clade": {
+                "type": "long"
+              }
+            }
+          },
+          "ontology_uri": {
+            "index": false,
+            "type": "keyword"
+          },
+          "uri": {
+            "index": false,
+            "type": "keyword"
+          },
+          "uuid": {
+            "type": "keyword"
+          },
+          "valid_within_clade": {
+            "type": "long"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/integration/v1/controlled_terms.js
+++ b/test/integration/v1/controlled_terms.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var request = require( "supertest" ),
+    iNaturalistAPI = require( "../../../lib/inaturalist_api" ),
+    app = iNaturalistAPI.server( );
+
+describe( "ControlledTerms", ( ) => {
+  describe( "search", ( ) => {
+    it( "returns json", done => {
+      request( app ).get( "/v1/controlled_terms" ).
+        expect( "Content-Type", /json/ ).expect( 200, done );
+    } );
+  } );
+} );


### PR DESCRIPTION
Adds ability to search for observations that lack certain annotations. Also adds an API endpoint for retrieving all controlled terms.