### PR TITLE
Obs index changes

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -933,7 +933,55 @@ ObservationsController.identifiers = function( req, callback ) {
     }
   };
   ESModel.userAggregationResponse( req, countQuery,
-    ObservationsController.elasticResults, callback );
+    ObservationsController.elasticResults, ( err, oldIDsResponse ) => {
+      if ( err ) { return callback( err ); }
+      ObservationsController.identifiersNewFormat( req, callback, oldIDsResponse );
+    }
+  );
+};
+
+ObservationsController.identifiersNewFormat = ( req, callback, oldIDsResponse) => {
+  var countQuery = _.extend( { }, req.query );
+  InaturalistAPI.setPerPage( req, { default: 500, max: 500 } );
+  countQuery.aggs = {
+    nested: {
+      nested: { path: "identifications" },
+      aggs: {
+        filtered: {
+          filter: { term: { "identifications.own_observation": false } },
+          aggs: {
+            total: { cardinality: { field: "identifications.user.id", precision_threshold: 10000 } },
+            users: {
+              terms: { field: "identifications.user.id", size: req.query.per_page || 500 }
+            }
+          }
+        }
+      }
+    }
+  };
+  ESModel.userAggregationResponse( req, countQuery,
+    ObservationsController.elasticResults, ( err, newIDsResponse ) => {
+      if ( err ) { return callback( err ); }
+      let groupedUsers = { };
+      _.each( oldIDsResponse.results, r => {
+        groupedUsers[r.user.id] = groupedUsers[r.user.id] || { count: 0, user: r.user };
+        groupedUsers[r.user.id].count = groupedUsers[r.user.id].count + r.count;
+      });
+      _.each( newIDsResponse.results, r => {
+        groupedUsers[r.user.id] = groupedUsers[r.user.id] || { count: 0, user: r.user };
+        groupedUsers[r.user.id].count = groupedUsers[r.user.id].count + r.count;
+      });
+      const sortedUsers = _.sortBy( _.values( groupedUsers ), r => r.count ).reverse( );
+      const results = _.first( sortedUsers, req.query.per_page );
+      const combinedResponse = {
+        total_results: _.max( [oldIDsResponse.total_results, newIDsResponse.total+results] ),
+        per_page: results.length,
+        page: 1,
+        results: results
+      }
+      callback( null, combinedResponse );
+    }
+  );
 };
 
 ObservationsController.observers = function( req, callback ) {

--- a/lib/models/es_model.js
+++ b/lib/models/es_model.js
@@ -106,6 +106,9 @@ var ESModel = class ESModel {
       if( aggs.nested ) {
         aggs = aggs.nested;
       }
+      if( aggs.filtered ) {
+        aggs = aggs.filtered;
+      }
       var buckets = _.map( aggs.users.buckets, function( b ) {
         return { user_id: b.key, count: b.doc_count };
       });

--- a/lib/models/es_model.js
+++ b/lib/models/es_model.js
@@ -109,6 +109,14 @@ var ESModel = class ESModel {
       if( aggs.filtered ) {
         aggs = aggs.filtered;
       }
+      if ( !aggs.users ) {
+        return callback( null, {
+          total_results: 0,
+          page: 1,
+          per_page: 0,
+          results: [ ]
+        });
+      }
       var buckets = _.map( aggs.users.buckets, function( b ) {
         return { user_id: b.key, count: b.doc_count };
       });


### PR DESCRIPTION
change identifiers ES query to look at both non_owner_ids and identifications, so queries work while re-indexing