### PR TITLE
Experiment with identifications/similar_species returning genera

### DIFF
--- a/lib/controllers/v1/identifications_controller.js
+++ b/lib/controllers/v1/identifications_controller.js
@@ -279,6 +279,9 @@ const IdentificationsController = class IdentificationsController {
       if ( !taxon ) {
         return void callback( { error: `Unknown taxon ${req.query.taxon_id}`, status: 422 } );
       }
+      if ( taxon.rank_level > 20 ) {
+        return void callback( { error: `Taxon ${req.query.taxon_id} is not genus or finer`, status: 422 } );
+      }
       const sharedQuery = {
         current: "any",
         current_taxon: "false",
@@ -287,31 +290,33 @@ const IdentificationsController = class IdentificationsController {
         preferred_place_id: req.query.preferred_place_id,
         place_id: req.query.place_id
       };
+      // First get idents of this taxon on obs not of this taxon
       let idQuery = _.assignIn( { }, sharedQuery, {
         taxon_id: req.query.taxon_id,
         observation_iconic_taxon_id: taxon.iconic_taxon_id,
         without_observation_taxon_id: req.query.taxon_id,
-        observation_rank: "species",
         observation_taxon_active: "true"
       } );
       // return species which are commonly mis-ID'd as this species
-      const speciesCountsReq1 = Object.assign( {}, req, { query: idQuery, inat: req.inat } );
+      const inat = Object.assign( {}, req.inat, { taxonAncestries: true } );
+      const speciesCountsReq1 = Object.assign( {}, req, { query: idQuery, inat } );
       IdentificationsController.speciesCountsWithOptions( speciesCountsReq1, { photos: true },
         ( errr, rsp1 ) => {
           if ( err ) { return void callback( errr ); }
+          // Then get idents not of this taxon on obs of this taxon
           idQuery = _.assignIn( { }, sharedQuery, {
             observation_taxon_id: req.query.taxon_id,
             iconic_taxon_id: taxon.iconic_taxon_id,
             without_taxon_id: req.query.taxon_id,
-            rank: "species",
             taxon_of: "identification",
             taxon_active: "true"
           } );
-          const speciesCountsReq2 = Object.assign( {}, req, { query: idQuery, inat: req.inat } );
+          const speciesCountsReq2 = Object.assign( {}, req, { query: idQuery, inat } );
           // return incorrect species IDs which end up as this species
           IdentificationsController.speciesCountsWithOptions( speciesCountsReq2, { photos: true },
             ( errrr, rsp2 ) => {
               if ( errrr ) { return void callback( errrr ); }
+              // And combine the two sets of results
               const { results } = rsp1;
               _.each( rsp2.results, res2 => {
                 const same = _.find( results, r => r.taxon.id === res2.taxon.id );
@@ -322,11 +327,34 @@ const IdentificationsController = class IdentificationsController {
                   results.push( res2 );
                 }
               } );
+              // Derive the taxa that match the rank of the requested taxon.
+              // This will mostly just show genera implied by situations where
+              // species have been mistaken for one another, and there's
+              // probably a bunch of complex situations it will miss, like genus
+              // IDs that disagree with species, etc.
+              const rankResults = [];
+              _.each( results, r => {
+                let rankMatch = r;
+                if ( r.taxon.rank !== taxon.rank ) {
+                  const rankMatchTaxon = _.find( r.taxon.ancestors, a => a.rank === taxon.rank );
+                  if ( rankMatchTaxon ) {
+                    rankMatch = Object.assign( {}, r, { taxon: rankMatchTaxon } );
+                  }
+                }
+                if ( rankMatch ) {
+                  const existing = _.find( rankResults, rr => rr.taxon.id === rankMatch.taxon.id );
+                  if ( existing ) {
+                    existing.count += rankMatch.count;
+                  } else {
+                    rankResults.push( rankMatch );
+                  }
+                }
+              } );
               callback( null, {
-                total_results: results.length,
+                total_results: rankResults.length,
                 page: 1,
-                per_page: results.length,
-                results: _.sortBy( results, r => -1 * r.count )
+                per_page: rankResults.length,
+                results: _.sortBy( rankResults, r => -1 * r.count )
               } );
             } );
         } );


### PR DESCRIPTION
Does this look like much of a performance burn, Patrick? Not convinced returning matching ranks is even useful, but I'm curious how much of a liability this approach presents. See https://forum.inaturalist.org/t/taxon-page-add-a-similar-taxa-tab-to-ranks-other-than-species for reference.