### PR TITLE
Require UUID for /v1/observations/{id}

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+    root: src

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   - psql -c 'create database inaturalist_test;' -U postgres
   - psql -f schema/database.sql -U postgres -d inaturalist_test
   - touch vision-taxa.txt
-  - sleep 25
+  - sleep 30
 
 after_script:
   - npm run coveralls

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -98,15 +98,11 @@ ObservationsController.viewedUpdates = ( req, callback ) => {
 ObservationsController.show = ( req, callback ) => {
   const ids = _.filter( req.params.id.split( "," ), _.identity ).slice( 0, 200 );
   // also preserve the ttl and locale params
-  req.query = {
+  req.query = Object.assign( req.query, {
     id: ids,
-    ttl: req.query.ttl,
-    locale: req.query.locale,
-    preferred_place_id: req.query.preferred_place_id,
-    include_new_projects: req.query.include_new_projects,
     details: "all",
     per_page: ids.length
-  };
+  } );
   ObservationsController.searchCacheWrapper( req, callback );
 };
 

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -684,6 +684,7 @@ ObservationsController.reqToElasticQueryComponents = ( req, callback ) => {
     { http_param: "week", es_field: "observed_on_details.week" },
     { http_param: "site_id", es_field: "site_id" },
     { http_param: "id", es_field: "id" },
+    { http_param: "uuid", es_field: "uuid" },
     { http_param: "license", es_field: "license_code" },
     { http_param: "photo_license", es_field: ["photos.license_code", "photo_licenses"] },
     { http_param: "sound_license", es_field: ["sounds.license_code", "sound_licenses"] },

--- a/lib/controllers/v2/observations_controller.js
+++ b/lib/controllers/v2/observations_controller.js
@@ -1,0 +1,16 @@
+const ctrlv1 = require( "../v1/observations_controller" );
+
+const show = ( req, callback ) => {
+  const uuids = req.params.id.slice( 0, 200 );
+  req.query = Object.assign( req.query, {
+    uuid: uuids,
+    details: "all",
+    per_page: uuids.length
+  } );
+  ctrlv1.searchCacheWrapper( req, callback );
+};
+
+module.exports = {
+  show,
+  search: ctrlv1.search
+};

--- a/lib/controllers/v2/observations_controller.js
+++ b/lib/controllers/v2/observations_controller.js
@@ -1,7 +1,7 @@
 const ctrlv1 = require( "../v1/observations_controller" );
 
 const show = ( req, callback ) => {
-  const uuids = req.params.id.slice( 0, 200 );
+  const uuids = req.params.uuid.slice( 0, 200 );
   req.query = Object.assign( req.query, {
     uuid: uuids,
     details: "all",

--- a/openapi/joi_to_openapi_parameter/index.js
+++ b/openapi/joi_to_openapi_parameter/index.js
@@ -5,6 +5,7 @@ const booleanParser = require( "./types/boolean" );
 const arrayParser = require( "./types/array" );
 const dateParser = require( "./types/date" );
 const objectParser = require( "./types/object" );
+const alternativesParser = require( "./types/alternatives" );
 
 const universalDecorator = joiSchema => {
   const universalParams = { };
@@ -70,7 +71,7 @@ const convert = joiSchema => {
     //   swaggerSchema = binaryParser( joiSchema );
     //   break;
     // case "alternatives":
-    //   swaggerSchema = alternativesParser( joiSchema, convert );
+    //   schema = alternativesParser( joiSchema, convert );
     //   break;
     case "object":
       schema = objectParser( joiSchema, convert );

--- a/openapi/joi_to_openapi_parameter/types/alternatives.js
+++ b/openapi/joi_to_openapi_parameter/types/alternatives.js
@@ -1,0 +1,6 @@
+// Note: I think this creates a valid OpenAPI schema, but it doesn't work with
+// object coersion, which seems to expect an explicitly typed definition
+// ~~kueda 2020-01-09
+module.exports = ( joiSchema, convert ) => ( {
+  anyOf: joiSchema._inner.matches.map( match => convert( match.schema ).schema )
+} );

--- a/openapi/joi_to_openapi_parameter/types/array.js
+++ b/openapi/joi_to_openapi_parameter/types/array.js
@@ -4,7 +4,7 @@ const getChild = ( items, convert ) => {
   if ( items.length === 1 ) {
     return { items: convert( items[0] ).schema };
   }
-  return { items: { anyOf: _.map( items, i => ( { type: i._type } ) ) } };
+  return { items: { anyOf: _.map( items, i => ( convert( i ).schema ) ) } };
 };
 
 const getLength = tests => {

--- a/openapi/paths/v2/observations.js
+++ b/openapi/paths/v2/observations.js
@@ -3,7 +3,7 @@ const j2s = require( "hapi-joi-to-swagger" );
 const observationsCreateSchema = require( "../../schema/request/observations_create" );
 const observationsSearchSchema = require( "../../schema/request/observations_search" );
 const transform = require( "../../joi_to_openapi_parameter" );
-const ObservationsController = require( "../../../lib/controllers/v1/observations_controller" );
+const ObservationsController = require( "../../../lib/controllers/v2/observations_controller" );
 
 
 module.exports = sendWrapper => {

--- a/openapi/paths/v2/observations.js
+++ b/openapi/paths/v2/observations.js
@@ -1,7 +1,12 @@
 const _ = require( "lodash" );
+// We use this to convert Joi schema definitions to swagger/openapi response
+// schemas. Joi is a slightly more concise, JS-style of expressing a schema
 const j2s = require( "hapi-joi-to-swagger" );
 const observationsCreateSchema = require( "../../schema/request/observations_create" );
 const observationsSearchSchema = require( "../../schema/request/observations_search" );
+// This is a custom method to convert Joi schema definitions to swagger/openapi
+// parameter definitions, which are different from the response definitions that
+// hapi-join-to-swagger handles
 const transform = require( "../../joi_to_openapi_parameter" );
 const ObservationsController = require( "../../../lib/controllers/v2/observations_controller" );
 

--- a/openapi/paths/v2/observations/{id}.js
+++ b/openapi/paths/v2/observations/{id}.js
@@ -1,10 +1,9 @@
 const Joi = require( "@hapi/joi" );
 const transform = require( "../../../joi_to_openapi_parameter" );
-const observationsController = require( "../../../../lib/controllers/v1/observations_controller" );
+const observationsController = require( "../../../../lib/controllers/v2/observations_controller" );
 
 module.exports = sendWrapper => {
   async function GET( req, res ) {
-    req.params.id = req.params.id.join( "," );
     observationsController.show( req, ( err, results ) => {
       sendWrapper( req, res, err, results );
     } );
@@ -17,8 +16,7 @@ module.exports = sendWrapper => {
       jwtOptional: []
     }],
     parameters: [
-      transform( Joi.array( ).items( Joi.number( ).integer( ) ).label( "id" ).meta( { in: "path" } )
-        .required( ) ),
+      transform( Joi.array( ).items( Joi.string( ).guid( ) ).label( "id" ).meta( { in: "path" } ) ),
       transform( Joi.string( ).label( "fields" ).meta( { in: "query" } ) )
     ],
     responses: {

--- a/openapi/paths/v2/observations/{id}.js
+++ b/openapi/paths/v2/observations/{id}.js
@@ -1,6 +1,4 @@
-const _ = require( "lodash" );
 const Joi = require( "@hapi/joi" );
-const observationsSearchSchema = require( "../../../schema/request/observations_search" );
 const transform = require( "../../../joi_to_openapi_parameter" );
 const observationsController = require( "../../../../lib/controllers/v1/observations_controller" );
 
@@ -20,7 +18,8 @@ module.exports = sendWrapper => {
     }],
     parameters: [
       transform( Joi.array( ).items( Joi.number( ).integer( ) ).label( "id" ).meta( { in: "path" } )
-        .required( ) )
+        .required( ) ),
+      transform( Joi.string( ).label( "fields" ).meta( { in: "query" } ) )
     ],
     responses: {
       200: {

--- a/openapi/paths/v2/observations/{uuid}.js
+++ b/openapi/paths/v2/observations/{uuid}.js
@@ -16,7 +16,14 @@ module.exports = sendWrapper => {
       jwtOptional: []
     }],
     parameters: [
-      transform( Joi.array( ).items( Joi.string( ).guid( ) ).label( "id" ).meta( { in: "path" } ) ),
+      transform(
+        Joi.array( )
+          .items( Joi.string( ).guid( ) )
+          .label( "uuid" )
+          .meta( { in: "path" } )
+          .required( )
+          .description( "A single UUID or a comma-separated list of them" )
+      ),
       transform( Joi.string( ).label( "fields" ).meta( { in: "query" } ) )
     ],
     responses: {
@@ -33,7 +40,31 @@ module.exports = sendWrapper => {
     }
   };
 
+  // async function PUT( req, res ) {
+  //   observationsController.update( req, ( err, results ) => {
+  //     sendWrapper( req, res, err, results );
+  //   } );
+  // }
+
+  // PUT.apiDoc = {
+  //   tags: ["Observations"],
+  //   summary: "Update an observation",
+  //   security: [{
+  //     jwtRequired: []
+  //   }],
+  //   parameters: [
+  //     transform(
+  //       Joi.string( ).guid( )
+  //         .label( "uuid" )
+  //         .meta( { in: "path" } )
+  //         .required( )
+  //         .description( "UUID of the observation to update" )
+  //     )
+  //   ]
+  // }
+
   return {
     GET
+    // PUT
   };
 };

--- a/openapi/schema/request/observations_search.js
+++ b/openapi/schema/request/observations_search.js
@@ -237,5 +237,5 @@ module.exports = Joi.object( ).keys( {
     "created_at"
   ),
   only_id: Joi.boolean( ),
-  fields: Joi.object( )
+  fields: Joi.any( )
 } ).unknown( false );

--- a/openapi/schema/response/observation.js
+++ b/openapi/schema/response/observation.js
@@ -16,8 +16,7 @@ const vote = require( "./vote" );
 
 module.exports = Joi.object( ).keys( {
   id: Joi.number( ).integer( )
-    .description( "Unique auto-increment integer identifier." )
-    .required( ),
+    .description( "Unique auto-increment integer identifier." ),
   annotations: Joi.array( ).items( annotation ),
   application: Joi.object( ).keys( {
     id: Joi.number( ).integer( ),
@@ -114,6 +113,6 @@ module.exports = Joi.object( ).keys( {
   updated_at: Joi.string( ),
   uri: Joi.string( ),
   user,
-  uuid: Joi.string( ).guid( { version: "uuidv4" } ),
+  uuid: Joi.string( ).guid( { version: "uuidv4" } ).required( ),
   votes: Joi.array( ).items( vote )
 } ).unknown( false ).meta( { className: "Observation" } );

--- a/openapi_app.js
+++ b/openapi_app.js
@@ -13,311 +13,316 @@ const v1ApiDoc = require( "./openapi/doc" );
 const util = require( "./lib/util" );
 const Logstasher = require( "./lib/logstasher" );
 
-const logstashPath = path.join(
-  path.dirname( fs.realpathSync( __filename ) ), "./log", "inaturalist_api.4000.log"
-);
-Logstasher.setLogStreamFilePath( logstashPath );
+const main = ( ) => {
+  const logstashPath = path.join(
+    path.dirname( fs.realpathSync( __filename ) ), "./log", "inaturalist_api.4000.log"
+  );
+  Logstasher.setLogStreamFilePath( logstashPath );
 
-const InaturalistAPI = require( "./lib/inaturalist_api" ); // eslint-disable-line global-require
+  const InaturalistAPI = require( "./lib/inaturalist_api" ); // eslint-disable-line global-require
 
-const app = InaturalistAPI.server( );
+  const app = InaturalistAPI.server( );
 
-let initializedApi = null;
+  let initializedApi = null;
 
-const sendWrapper = ( req, res, err, results ) => {
-  if ( err ) { return void initializedApi.args.errorMiddleware( err, null, res, null ); }
-  res.status( 200 ).header( "Content-Type", "application/json" ).send( results );
-};
+  const sendWrapper = ( req, res, err, results ) => {
+    if ( err ) { return void initializedApi.args.errorMiddleware( err, null, res, null ); }
+    res.status( 200 ).header( "Content-Type", "application/json" ).send( results );
+  };
 
-app.use( bodyParser.json( {
-  type: req => {
-    // Parser the request body for everything other than multipart requests,
-    // which should specify body data as plain old form data which express can
-    // parse on its own.
-    if ( !req.headers["content-type"] ) {
-      return true;
+  app.use( bodyParser.json( {
+    type: req => {
+      // Parser the request body for everything other than multipart requests,
+      // which should specify body data as plain old form data which express can
+      // parse on its own.
+      if ( !req.headers["content-type"] ) {
+        return true;
+      }
+      return req.headers["content-type"].match( /multipart/ ) === null;
     }
-    return req.headers["content-type"].match( /multipart/ ) === null;
-  }
-} ) );
+  } ) );
 
 
-app.use( ( req, res, next ) => {
-  util.timingMiddleware( req, res, next );
-} );
+  app.use( ( req, res, next ) => {
+    util.timingMiddleware( req, res, next );
+  } );
 
-app.use( ( req, res, next ) => {
-  const methodOverride = req.header( "X-HTTP-Method-Override" );
-  if ( req.method === "POST" && methodOverride === "GET" && initializedApi ) {
-    const basePath = initializedApi.basePaths[0].path;
-    const basePathRegex = new RegExp( `^${_.escapeRegExp( basePath )}` );
-    const apiPath = req.path.replace( basePathRegex, "" );
-    const apiMethod = initializedApi.apiDoc.paths[apiPath];
-    if ( apiMethod && apiMethod.post ) {
-      const allowsOverride = _.find( apiMethod.post.parameters, p => (
-        p.name === "X-HTTP-Method-Override" && p.in === "header"
-      ) );
-      if ( allowsOverride ) {
-        req.originalMethod = req.originalMethod || req.method;
-        req.method = "GET";
+  app.use( ( req, res, next ) => {
+    const methodOverride = req.header( "X-HTTP-Method-Override" );
+    if ( req.method === "POST" && methodOverride === "GET" && initializedApi ) {
+      const basePath = initializedApi.basePaths[0].path;
+      const basePathRegex = new RegExp( `^${_.escapeRegExp( basePath )}` );
+      const apiPath = req.path.replace( basePathRegex, "" );
+      const apiMethod = initializedApi.apiDoc.paths[apiPath];
+      if ( apiMethod && apiMethod.post ) {
+        const allowsOverride = _.find( apiMethod.post.parameters, p => (
+          p.name === "X-HTTP-Method-Override" && p.in === "header"
+        ) );
+        if ( allowsOverride ) {
+          req.originalMethod = req.originalMethod || req.method;
+          req.method = "GET";
+        }
       }
     }
-  }
-  next( );
-} );
+    next( );
+  } );
 
-const storage = multer.diskStorage( {
-  destination: ( req, file, callback ) => {
-    crypto.pseudoRandomBytes( 16, ( err, raw ) => {
-      const time = Date.now( );
-      const hash = raw.toString( "hex" );
-      // create a directory in which to store the upload
-      const uploadDir = `openapi/uploads/tmp_${time}_${hash}`;
-      if ( !fs.existsSync( uploadDir ) ) {
-        fs.mkdirSync( uploadDir );
+  const storage = multer.diskStorage( {
+    destination: ( req, file, callback ) => {
+      crypto.pseudoRandomBytes( 16, ( err, raw ) => {
+        const time = Date.now( );
+        const hash = raw.toString( "hex" );
+        // create a directory in which to store the upload
+        const uploadDir = `openapi/uploads/tmp_${time}_${hash}`;
+        if ( !fs.existsSync( uploadDir ) ) {
+          fs.mkdirSync( uploadDir );
+        }
+        callback( null, uploadDir );
+      } );
+    },
+    filename: ( req, file, callback ) => callback( null, file.originalname )
+  } );
+
+  const upload = multer( { storage } );
+
+  const resolveSchema = ( req, schema ) => {
+    const schemaRef = schema.$ref;
+    if ( schemaRef && schemaRef.match( /#\/components\/schemas\// ) ) {
+      const schemaName = schemaRef.replace( "#/components/schemas/", "" );
+      return req.apiDoc.components.schemas[schemaName];
+    }
+    return schema;
+  };
+
+  const requestFields = req => {
+    const fields = req.body.fields || req.query.fields;
+    if ( _.isObject( fields ) ) {
+      return fields;
+    }
+    if ( !_.isEmpty( fields ) ) {
+      try {
+        const fieldsJson = JSON.parse( fields );
+        return fieldsJson;
+      } catch {
+        // ignore parse failures
       }
-      callback( null, uploadDir );
+      const fieldsStringMatch = fields.match( /^[a-z_]+(,[a-z_]+)?$/ );
+      if ( fieldsStringMatch ) {
+        return fields.split( "," );
+      }
+      return false;
+    }
+    return null;
+  };
+
+  const responseItemSchema = req => {
+    if ( req.operationDoc
+      && req.operationDoc.responses["200"]
+      && req.operationDoc.responses["200"].content["application/json"]
+      && req.operationDoc.responses["200"].content["application/json"].schema ) {
+      const responseSchema = resolveSchema( req,
+        req.operationDoc.responses["200"].content["application/json"].schema );
+      if ( responseSchema.properties
+        && responseSchema.properties.results
+        && responseSchema.properties.results.items ) {
+        return resolveSchema( req, responseSchema.properties.results );
+      }
+    }
+    return null;
+  };
+
+  let applyFieldSelectionToItem = ( ) => { };
+  const applyFieldSelectionToObject = ( req, item, fieldsRequested, itemSchema ) => {
+    let fieldsToReturn = { };
+    _.each( itemSchema.required, k => {
+      fieldsToReturn[k] = true;
     } );
-  },
-  filename: ( req, file, callback ) => callback( null, file.originalname )
-} );
-
-const upload = multer( { storage } );
-
-const resolveSchema = ( req, schema ) => {
-  const schemaRef = schema.$ref;
-  if ( schemaRef && schemaRef.match( /#\/components\/schemas\// ) ) {
-    const schemaName = schemaRef.replace( "#/components/schemas/", "" );
-    return req.apiDoc.components.schemas[schemaName];
-  }
-  return schema;
-};
-
-const requestFields = req => {
-  const fields = req.body.fields || req.query.fields;
-  if ( _.isObject( fields ) ) {
-    return fields;
-  }
-  if ( !_.isEmpty( fields ) ) {
-    try {
-      const fieldsJson = JSON.parse( fields );
-      return fieldsJson;
-    } catch {
-      // ignore parse failures
+    if ( _.isArray( fieldsRequested ) ) {
+      fieldsToReturn = Object.assign( fieldsToReturn, _.keyBy( fieldsRequested, r => r ) );
+    } else {
+      fieldsToReturn = Object.assign( fieldsToReturn, fieldsRequested );
     }
-    const fieldsStringMatch = fields.match( /^[a-z_]+(,[a-z_]+)?$/ );
-    if ( fieldsStringMatch ) {
-      return fields.split( "," );
-    }
-    return false;
-  }
-  return null;
-};
-
-const responseItemSchema = req => {
-  if ( req.operationDoc
-    && req.operationDoc.responses["200"]
-    && req.operationDoc.responses["200"].content["application/json"]
-    && req.operationDoc.responses["200"].content["application/json"].schema ) {
-    const responseSchema = resolveSchema( req,
-      req.operationDoc.responses["200"].content["application/json"].schema );
-    if ( responseSchema.properties
-      && responseSchema.properties.results
-      && responseSchema.properties.results.items ) {
-      return resolveSchema( req, responseSchema.properties.results );
-    }
-  }
-  return null;
-};
-
-let applyFieldSelectionToItem = ( ) => { };
-const applyFieldSelectionToObject = ( req, item, fieldsRequested, itemSchema ) => {
-  let fieldsToReturn = { };
-  _.each( itemSchema.required, k => {
-    fieldsToReturn[k] = true;
-  } );
-  if ( _.isArray( fieldsRequested ) ) {
-    fieldsToReturn = Object.assign( fieldsToReturn, _.keyBy( fieldsRequested, r => r ) );
-  } else {
-    fieldsToReturn = Object.assign( fieldsToReturn, fieldsRequested );
-  }
-  const prunedItem = { };
-  // loop through the requested fields
-  _.each( fieldsToReturn, ( v, k ) => {
-    // the root item has the field, and is in the root item definition
-    const fieldSchema = itemSchema.properties[k];
-    if ( item[k] && fieldSchema ) {
-      const propertySchema = resolveSchema( req, fieldSchema );
-      prunedItem[k] = applyFieldSelectionToItem( req, item[k], v, propertySchema );
-    }
-  } );
-  return prunedItem;
-};
-
-applyFieldSelectionToItem = ( req, item, fields, itemSchema ) => {
-  if ( itemSchema.type === "array" && _.isArray( item ) ) {
-    item = _.map( item, i => applyFieldSelectionToItem(
-      req, i, fields, resolveSchema( req, itemSchema.items )
-    ) );
-  } else if ( itemSchema.type === "object" && _.isObject( item ) ) {
-    item = applyFieldSelectionToObject( req, item, fields, itemSchema );
-  }
-  return item;
-};
-
-const validateAllResponses = ( req, res, next ) => {
-  const strictValidation = !!req.apiDoc["x-express-openapi-validation-strict"];
-  if ( typeof res.validateResponse === "function" ) {
-    const { send } = res;
-    res.send = ( ...args ) => {
-      const onlyWarn = !strictValidation;
-      if ( res.get( "x-express-openapi-validated" ) !== undefined ) {
-        return send.apply( res, args );
+    const prunedItem = { };
+    // loop through the requested fields
+    _.each( fieldsToReturn, ( v, k ) => {
+      // the root item has the field, and is in the root item definition
+      const fieldSchema = itemSchema.properties[k];
+      if ( item[k] && fieldSchema ) {
+        const propertySchema = resolveSchema( req, fieldSchema );
+        prunedItem[k] = applyFieldSelectionToItem( req, item[k], v, propertySchema );
       }
-      const body = args[0];
-      const itemSchema = responseItemSchema( req );
-      if ( body && !_.isEmpty( body.results ) && itemSchema ) {
-        const fields = requestFields( req );
-        if ( fields === false ) {
-          res.set( "x-express-openapi-validated", true );
-          return sendWrapper( req, res, new Error( "invalid fields parameter" ) );
+    } );
+    return prunedItem;
+  };
+
+  applyFieldSelectionToItem = ( req, item, fields, itemSchema ) => {
+    if ( itemSchema.type === "array" && _.isArray( item ) ) {
+      item = _.map( item, i => applyFieldSelectionToItem(
+        req, i, fields, resolveSchema( req, itemSchema.items )
+      ) );
+    } else if ( itemSchema.type === "object" && _.isObject( item ) ) {
+      item = applyFieldSelectionToObject( req, item, fields, itemSchema );
+    }
+    return item;
+  };
+
+  const validateAllResponses = ( req, res, next ) => {
+    const strictValidation = !!req.apiDoc["x-express-openapi-validation-strict"];
+    if ( typeof res.validateResponse === "function" ) {
+      const { send } = res;
+      res.send = ( ...args ) => {
+        const onlyWarn = !strictValidation;
+        if ( res.get( "x-express-openapi-validated" ) !== undefined ) {
+          return send.apply( res, args );
         }
-        if ( fields !== "all" ) {
-          body.results = applyFieldSelectionToItem( req, body.results, fields, itemSchema );
+        const body = args[0];
+        const itemSchema = responseItemSchema( req );
+        if ( body && !_.isEmpty( body.results ) && itemSchema ) {
+          const fields = requestFields( req );
+          if ( fields === false ) {
+            res.set( "x-express-openapi-validated", true );
+            return sendWrapper( req, res, new Error( "invalid fields parameter" ) );
+          }
+          if ( fields !== "all" ) {
+            body.results = applyFieldSelectionToItem( req, body.results, fields, itemSchema );
+          }
         }
-      }
 
-      let validation = res.validateResponse( res.statusCode, body );
-      let validationMessage;
-      if ( validation === undefined ) {
-        validation = { message: undefined, errors: undefined };
-      }
-      if ( validation.errors ) {
-        const errorList = Array.from( validation.errors ).map( e => e.message ).join( "," );
-        validationMessage = `Invalid response for status code ${res.statusCode}: ${errorList}`;
-        console.warn( ["validationMessage", validationMessage] );
-        // Set to avoid a loop, and to provide the original status code
-        res.set( "x-express-openapi-validation-error-for", res.statusCode.toString( ) );
-      }
-      res.set( "x-express-openapi-validated", true );
-      if ( onlyWarn || !validation.errors ) {
-        if ( _.has( req.originalQuery || req.query, "pretty" ) ) {
-          args[0] = JSON.stringify( body, null, 2 );
+        let validation = res.validateResponse( res.statusCode, body );
+        let validationMessage;
+        if ( validation === undefined ) {
+          validation = { message: undefined, errors: undefined };
         }
-        return send.apply( res, args );
-      }
-      return sendWrapper( req, res, new Error( validationMessage ) );
-    };
-  }
-  next( );
-};
+        if ( validation.errors ) {
+          const errorList = Array.from( validation.errors ).map( e => e.message ).join( "," );
+          validationMessage = `Invalid response for status code ${res.statusCode}: ${errorList}`;
+          console.warn( ["validationMessage", validationMessage] );
+          // Set to avoid a loop, and to provide the original status code
+          res.set( "x-express-openapi-validation-error-for", res.statusCode.toString( ) );
+        }
+        res.set( "x-express-openapi-validated", true );
+        if ( onlyWarn || !validation.errors ) {
+          if ( _.has( req.originalQuery || req.query, "pretty" ) ) {
+            args[0] = JSON.stringify( body, null, 2 );
+          }
+          return send.apply( res, args );
+        }
+        return sendWrapper( req, res, new Error( validationMessage ) );
+      };
+    }
+    next( );
+  };
 
-const jwtValidate = req => new Promise( resolve => {
-  if ( !req.headers.authorization ) {
-    return void resolve( );
-  }
-  const token = _.last( req.headers.authorization.split( /\s+/ ) );
-  jwt.verify( token, config.jwtSecret || "secret", { algorithms: ["HS512"] }, ( err, payload ) => {
-    if ( err ) {
+  const jwtValidate = req => new Promise( resolve => {
+    if ( !req.headers.authorization ) {
       return void resolve( );
     }
-    req.userSession = payload;
-    resolve( true );
+    const token = _.last( req.headers.authorization.split( /\s+/ ) );
+    jwt.verify( token, config.jwtSecret || "secret", { algorithms: ["HS512"] }, ( err, payload ) => {
+      if ( err ) {
+        return void resolve( );
+      }
+      req.userSession = payload;
+      resolve( true );
+    } );
   } );
-} );
 
-initializedApi = initialize( {
-  app,
-  docPath: "api-docs",
-  apiDoc: {
-    ...v1ApiDoc,
-    "x-express-openapi-additional-middleware": [validateAllResponses],
-    "x-express-openapi-validation-strict": true
-  },
-  enableObjectCoercion: true,
-  dependencies: {
-    sendWrapper
-  },
-  securityFilter: ( req, res ) => {
-    // remove x-express-* attributes which don't need to be in the official documentation
-    res.status( 200 ).json( _.pickBy( req.apiDoc, ( value, key ) => !key.match( /^x-/ ) ) );
-  },
-  paths: "./openapi/paths/v2",
-  promiseMode: true,
-  securityHandlers: {
-    jwtOptional: req => jwtValidate( req ).then( ( ) => true ),
-    jwtRequired: req => jwtValidate( req )
-  },
-  consumesMiddleware: {
-    // TODO: custom coercion for JSON bodies?
-    "multipart/form-data": ( req, res, next ) => {
-      const knownUploadFields = [];
-      const { properties } = req.operationDoc.requestBody.content["multipart/form-data"].schema;
-      _.each( properties, ( schema, name ) => {
-        if ( schema.type === "string" && schema.format === "binary" ) {
-          knownUploadFields.push( name );
-        }
-      } );
-      const props = req.operationDoc.requestBody.content["multipart/form-data"].schema.properties;
-      const parameters = _.map( _.keys( props ), k => ( {
-        in: "formData",
-        name: k,
-        schema: req.operationDoc.requestBody.content["multipart/form-data"].schema.properties[k]
-      } ) );
-      const coercer = new openapiCoercer.default( {
-        extensionBase: "x-express-openapi-coercion",
-        loggingKey: "express-openapi-coercion",
-        parameters,
-        enableObjectCoercion: true
-      } );
-      coercer.coerce( req );
-
-      upload.fields( _.map( knownUploadFields, f => ( { name: f } ) ) )( req, res, err => {
-        const originalBody = _.cloneDeep( req.body );
-        const newBody = { };
-        _.each( originalBody, ( v, k ) => {
-          if ( _.isObject( v ) ) {
-            newBody[k] = { };
-            _.each( v, ( vv, kk ) => {
-              if ( vv !== "" ) {
-                newBody[k][kk] = vv;
-              }
-            } );
-          } else {
-            newBody[k] = v;
+  initializedApi = initialize( {
+    app,
+    docPath: "api-docs",
+    apiDoc: {
+      ...v1ApiDoc,
+      "x-express-openapi-additional-middleware": [validateAllResponses],
+      "x-express-openapi-validation-strict": true
+    },
+    enableObjectCoercion: true,
+    dependencies: {
+      sendWrapper
+    },
+    securityFilter: ( req, res ) => {
+      // remove x-express-* attributes which don't need to be in the official documentation
+      res.status( 200 ).json( _.pickBy( req.apiDoc, ( value, key ) => !key.match( /^x-/ ) ) );
+    },
+    paths: "./openapi/paths/v2",
+    promiseMode: true,
+    securityHandlers: {
+      jwtOptional: req => jwtValidate( req ).then( ( ) => true ),
+      jwtRequired: req => jwtValidate( req )
+    },
+    consumesMiddleware: {
+      // TODO: custom coercion for JSON bodies?
+      "multipart/form-data": ( req, res, next ) => {
+        const knownUploadFields = [];
+        const { properties } = req.operationDoc.requestBody.content["multipart/form-data"].schema;
+        _.each( properties, ( schema, name ) => {
+          if ( schema.type === "string" && schema.format === "binary" ) {
+            knownUploadFields.push( name );
           }
         } );
-        req.body = newBody;
+        const props = req.operationDoc.requestBody.content["multipart/form-data"].schema.properties;
+        const parameters = _.map( _.keys( props ), k => ( {
+          in: "formData",
+          name: k,
+          schema: req.operationDoc.requestBody.content["multipart/form-data"].schema.properties[k]
+        } ) );
+        const coercer = new openapiCoercer.default( {
+          extensionBase: "x-express-openapi-coercion",
+          loggingKey: "express-openapi-coercion",
+          parameters,
+          enableObjectCoercion: true
+        } );
         coercer.coerce( req );
-        next( );
-      } );
+
+        upload.fields( _.map( knownUploadFields, f => ( { name: f } ) ) )( req, res, err => {
+          const originalBody = _.cloneDeep( req.body );
+          const newBody = { };
+          _.each( originalBody, ( v, k ) => {
+            if ( _.isObject( v ) ) {
+              newBody[k] = { };
+              _.each( v, ( vv, kk ) => {
+                if ( vv !== "" ) {
+                  newBody[k][kk] = vv;
+                }
+              } );
+            } else {
+              newBody[k] = v;
+            }
+          } );
+          req.body = newBody;
+          coercer.coerce( req );
+          next( );
+        } );
+      }
+    },
+    // this needs all 4 parameters even if next is not used
+    /* eslint-disable-next-line no-unused-vars */
+    errorMiddleware: ( err, req, res, next ) => {
+      if ( err.errorCode === "authentication.openapi.security" ) {
+        res.status( err.status || 401 ).json( {
+          status: err.status || 401,
+          message: "Unauthorized"
+        } );
+        return;
+      }
+      console.log( "Error trace from errorMiddleware ------->" );
+      console.trace( err );
+      res.status( err.status || 500 ).json( err instanceof Error
+        ? {
+          status: 500,
+          message: err.message,
+          stack: err.stack.split( "\n" ),
+          from: "errorMiddleware"
+        } : err );
     }
-  },
-  // this needs all 4 parameters even if next is not used
-  /* eslint-disable-next-line no-unused-vars */
-  errorMiddleware: ( err, req, res, next ) => {
-    if ( err.errorCode === "authentication.openapi.security" ) {
-      res.status( err.status || 401 ).json( {
-        status: err.status || 401,
-        message: "Unauthorized"
-      } );
-      return;
-    }
-    console.log( "Error trace from errorMiddleware ------->" );
-    console.trace( err );
-    res.status( err.status || 500 ).json( err instanceof Error
-      ? {
-        status: 500,
-        message: err.message,
-        stack: err.stack.split( "\n" ),
-        from: "errorMiddleware"
-      } : err );
-  }
-} );
+  } );
 
+  app.get( "/v2/", ( req, res ) => res.redirect( "/v2/docs" ) );
+  app.use( "/v2/docs", swaggerUi.serve, swaggerUi.setup( initializedApi.apiDoc ) );
+  return app;
+};
 
-app.get( "/v2/", ( req, res ) => res.redirect( "/v2/docs" ) );
+if ( require.main === module ) {
+  main( ).listen( 4000 );
+}
 
-app.use( "/v2/docs", swaggerUi.serve, swaggerUi.setup( initializedApi.apiDoc ) );
-
-app.listen( 4000 );
+module.exports = main( );

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,120 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@jagql/framework": {
+      "version": "5.6.14",
+      "resolved": "https://registry.npmjs.org/@jagql/framework/-/framework-5.6.14.tgz",
+      "integrity": "sha512-saDnqqucxo9i5BVI9RBuCEyFuKkmT95wnN1KIh1uXmcOo/ODrPtcmgl2z2SqOi9IWHXan8j2gDoZ42MgH9pzUQ==",
+      "requires": {
+        "@types/express": "^4.11.1",
+        "@types/joi": "^14.0.0",
+        "async": "2.6.1",
+        "cookie-parser": "1.4.3",
+        "debug": "^4.1.0",
+        "express": "^4.16.4",
+        "express-graphql": "^0.7.1",
+        "graphql": "^14.0.0",
+        "joi": "^14.0.0",
+        "joi-date-extensions": "^1.2.0",
+        "lodash.assign": "4.2.0",
+        "lodash.isequal": "4.5.0",
+        "lodash.omit": "4.5.0",
+        "lodash.pick": "4.4.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.uniqby": "4.7.0",
+        "qs": "6.5.2",
+        "request": "2.88.0",
+        "use-strict": "1.0.1",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "express-graphql": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.7.1.tgz",
+          "integrity": "sha512-YpheAqTbSKpb5h57rV2yu2dPNUBi4FvZDspZ5iEV3ov34PBRgnM4lEBkv60+vZRJ6SweYL14N8AGYdov7g6ooQ==",
+          "requires": {
+            "accepts": "^1.3.5",
+            "content-type": "^1.0.4",
+            "http-errors": "^1.7.1",
+            "raw-body": "^2.3.3"
+          }
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
+      }
+    },
     "@mapbox/sphericalmercator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
@@ -318,6 +432,71 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/body-parser": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
+      "integrity": "sha512-9e7jj549ZI+RxY21Cl0t8uBnWyb22HzILupyHZjYEVK//5TT/1bZodU+yUbLnPdoYViBBnNWbxp4zYjGV0zUGw==",
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/joi": {
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.4.tgz",
+      "integrity": "sha512-1TQNDJvIKlgYXGNIABfgFp9y0FziDpuGrd799Q5RcnsDu+krD+eeW/0Fs5PHARvWWFelOhIG2OPCo6KbadBM4A=="
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+    },
+    "@types/node": {
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
+      "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
     "@tyriar/fibonacci-heap": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.8.tgz",
@@ -369,7 +548,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
       "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -380,14 +558,12 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         }
       }
     },
@@ -1110,6 +1286,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -1345,6 +1530,14 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "difunc": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/difunc/-/difunc-0.0.4.tgz",
+      "integrity": "sha512-zBiL4ALDmviHdoLC0g0G6wVme5bwAow9WfhcZLLopXCAWgg3AEf7RYTs2xugszIGulRHzEVDF/SHl9oyQU07Pw==",
+      "requires": {
+        "esprima": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1394,7 +1587,7 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "elasticmaps": {
-      "version": "github:inaturalist/elasticmaps#e3a19da2c3815bb3600b4e7b9efab9ee2be8f104",
+      "version": "github:inaturalist/elasticmaps#cf0bda3756a41e43d5c5894db587577d4cdb2324",
       "from": "github:inaturalist/elasticmaps",
       "requires": {
         "@mapbox/sphericalmercator": "^1.1.0",
@@ -1984,6 +2177,104 @@
         }
       }
     },
+    "express-graphql": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
+      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+      "requires": {
+        "accepts": "^1.3.7",
+        "content-type": "^1.0.4",
+        "http-errors": "^1.7.3",
+        "raw-body": "^2.4.1"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "requires": {
+            "mime-types": "~2.1.24",
+            "negotiator": "0.6.2"
+          }
+        },
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "requires": {
+            "mime-db": "1.43.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+        },
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
+      }
+    },
+    "express-normalize-query-params-middleware": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/express-normalize-query-params-middleware/-/express-normalize-query-params-middleware-0.5.1.tgz",
+      "integrity": "sha1-2+HoE5rssjT7attcAFnHXblzPSo="
+    },
+    "express-openapi": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/express-openapi/-/express-openapi-4.6.5.tgz",
+      "integrity": "sha512-jZWJXkphbpsqFrlrRF4BAnXhJImGW/T6YwuSpArjjDCK0rmsS0JF7etRAUDtmfpD06jFVLzpx0tgQ/hBN3e/wA==",
+      "requires": {
+        "express-normalize-query-params-middleware": "^0.5.0",
+        "openapi-framework": "0.24.5",
+        "openapi-types": "1.3.5"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2177,6 +2468,11 @@
         "minipass": "^2.6.0"
       }
     },
+    "fs-routes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-2.0.0.tgz",
+      "integrity": "sha512-oITW9GoYFZwYWR2aMDdUvr6W9O5mtzSizIVEUdeCQaFD6+BylwPSEP2+ZFWv1UYpE9kiPS3Hb0knh2PmFJcj6A=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2299,6 +2595,19 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graphql": {
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-fields": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz",
+      "integrity": "sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA=="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -2321,6 +2630,16 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
+      }
+    },
+    "hapi-joi-to-swagger": {
+      "version": "github:pleary/hapi-joi-to-swagger#6c17eccd5a6f6e3b0a50646ad83a6459c11f8809",
+      "from": "github:pleary/hapi-joi-to-swagger#6c17eccd5a6f6e3b0a50646ad83a6459c11f8809",
+      "requires": {
+        "lodash.find": "^4.0.0",
+        "lodash.get": "^4.0.2",
+        "lodash.merge": "~4.6.1",
+        "lodash.set": "~4.3.2"
       }
     },
     "har-schema": {
@@ -2388,6 +2707,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hoek": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -2472,7 +2796,7 @@
       "dev": true
     },
     "inaturalistjs": {
-      "version": "github:inaturalist/inaturalistjs#5def57c1f5f94c146a9af9d8ed82de8c62696fb2",
+      "version": "github:inaturalist/inaturalistjs#170f63c9ad966b96dd45407331fe7ccaadb512b7",
       "from": "github:inaturalist/inaturalistjs",
       "requires": {
         "cross-fetch": "^2.2.3"
@@ -2632,6 +2956,11 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-dir/-/is-dir-1.0.0.tgz",
+      "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8="
+    },
     "is-extended": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
@@ -2714,6 +3043,21 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2788,6 +3132,29 @@
         }
       }
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "joi": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "requires": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
+    },
+    "joi-date-extensions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/joi-date-extensions/-/joi-date-extensions-1.2.0.tgz",
+      "integrity": "sha512-rXuz2yGx/0TnG8rDBv5bqryOD7g6BvAYEs2BVt0yPWZsO1YiQd4mtHGQ4mqWt/ly/G47+ZRo/jxy02G2iACJHg==",
+      "requires": {
+        "moment": "2.x.x"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2798,7 +3165,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2994,6 +3360,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
@@ -3002,8 +3373,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -3014,6 +3384,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -3045,6 +3420,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -3055,10 +3435,30 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
     },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
     "lodash.repeat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
       "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -3691,6 +4091,134 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "openapi-default-setter": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-2.0.4.tgz",
+      "integrity": "sha512-u0yC81Me26w1Q5r9Q92+kYpHVc8ooXUaoNRzU281T+WNwabvaWluUebw1m5BRjkjDfGcv1P9bf/ocfDZjmvPkw==",
+      "requires": {
+        "openapi-types": "1.3.4"
+      },
+      "dependencies": {
+        "openapi-types": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
+          "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
+        }
+      }
+    },
+    "openapi-framework": {
+      "version": "0.24.5",
+      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-0.24.5.tgz",
+      "integrity": "sha512-H2zVBn28NaXF8IhhAc5+xcGkHjSD813QvoffTNG4aG2edx3/h1Z6y+x74+kRKi+fiFLGn+a36Ts2xbLYh+ODtg==",
+      "requires": {
+        "difunc": "0.0.4",
+        "fs-routes": "2.0.0",
+        "glob": "*",
+        "is-dir": "^1.0.0",
+        "js-yaml": "^3.10.0",
+        "openapi-default-setter": "2.0.4",
+        "openapi-request-coercer": "2.3.0",
+        "openapi-request-validator": "3.8.3",
+        "openapi-response-validator": "3.8.2",
+        "openapi-schema-validator": "3.0.3",
+        "openapi-security-handler": "2.0.4",
+        "openapi-types": "1.3.5",
+        "ts-log": "^2.1.4"
+      },
+      "dependencies": {
+        "openapi-request-coercer": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-2.3.0.tgz",
+          "integrity": "sha512-oLrxgYOS3CE+ystqeZEBlpxiuQy6Q5HNLMLj9ciMGdJL7x73NedVWkEU00RJ8acjqZJEm73IYMRhQ0D4De14/A==",
+          "requires": {
+            "openapi-types": "1.3.4"
+          },
+          "dependencies": {
+            "openapi-types": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
+              "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
+            }
+          }
+        }
+      }
+    },
+    "openapi-jsonschema-parameters": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-1.1.2.tgz",
+      "integrity": "sha512-i8nTpo28ZZyyGzp7K2v9foXMHjyVdyE6J/igV8UhSDpAXDllTN4hNfqL6+8STAbmkMkHdy3S3aTGkxXlb7GKqA==",
+      "requires": {
+        "openapi-types": "1.3.5"
+      }
+    },
+    "openapi-request-coercer": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-2.4.0.tgz",
+      "integrity": "sha512-UFRzW7C7Q31FUOFHEMYNeSuEmETH7KGlsMgMJanv0RxXkACyzKpKANPfM3oiMubQENPya3Ie9ZIq5HLvZEy/eQ==",
+      "requires": {
+        "openapi-types": "1.3.5",
+        "ts-log": "^2.1.4"
+      }
+    },
+    "openapi-request-validator": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.8.3.tgz",
+      "integrity": "sha512-pnkk5nqPxrhgG2NCACr6sNcaqQuJSOjAo6TP0RhDT1giIGdcsrISerR8QCeX1vmJseXNzq26mbQAwjftAKhZRQ==",
+      "requires": {
+        "ajv": "^6.5.4",
+        "content-type": "^1.0.4",
+        "openapi-jsonschema-parameters": "1.1.2",
+        "openapi-types": "1.3.5",
+        "ts-log": "^2.1.4"
+      }
+    },
+    "openapi-response-validator": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-3.8.2.tgz",
+      "integrity": "sha512-SZY8uHRcphr/4SdzvLDTyJ7P/f34E/ApCnp2A3S0cG1FkESa5qPg+4bA7z1YLsr1IglimdP+fVGA68aMLNk9mg==",
+      "requires": {
+        "ajv": "^6.5.4",
+        "openapi-types": "1.3.5"
+      }
+    },
+    "openapi-schema-validator": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-3.0.3.tgz",
+      "integrity": "sha512-KKpeNEvAmpy6B2JCfyrM4yWjL6vggDCVbBoR8Yfkj0Jltc6PCW+dBbcg+1yrTCuDv80qBQJ6w0ejA71DlOFegA==",
+      "requires": {
+        "ajv": "^6.5.2",
+        "lodash.merge": "^4.6.1",
+        "openapi-types": "1.3.4",
+        "swagger-schema-official": "2.0.0-bab6bed"
+      },
+      "dependencies": {
+        "openapi-types": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
+          "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
+        }
+      }
+    },
+    "openapi-security-handler": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-2.0.4.tgz",
+      "integrity": "sha512-blz/UftEqYQLAByuEVITePUI9hV5Rd91CEK8yrsKDUaf3zk6cmIMafJ2qvagHqjXRRtL7fOqvsSKIeFrai+HfQ==",
+      "requires": {
+        "openapi-types": "1.3.4"
+      },
+      "dependencies": {
+        "openapi-types": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
+          "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
+        }
+      }
+    },
+    "openapi-types": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
+      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
     },
     "optimist": {
       "version": "0.6.1",
@@ -4685,6 +5213,24 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+    },
+    "swagger-ui-dist": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.24.3.tgz",
+      "integrity": "sha512-kB8qobP42Xazaym7sD9g5mZuRL4416VIIYZMqPEIskkzKqbPLQGEiHA3ga31bdzyzFLgr6Z797+6X1Am6zYpbg=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.2.tgz",
+      "integrity": "sha512-bVT16qj6WdNlEKFkSLOoTeGuqEm2lfOFRq6mVHAx+viA/ikORE+n4CS3WpVcYmQzM4HE6+DUFgAWcMRBJNpjcw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "table": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
@@ -4744,6 +5290,19 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -4757,6 +5316,11 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "ts-log": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
+      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ=="
     },
     "tslib": {
       "version": "1.9.3",
@@ -4839,7 +5403,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -4847,10 +5410,14 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -4866,6 +5433,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -355,6 +355,7 @@
         },
         {
           "id": 2,
+          "uuid": "9a4046ff-2005-4c8c-8127-48ef2c8e3ab9",
           "user": { "id": 5 },
           "created_at": "2016-01-01T01:00:00",
           "location": "2,3",
@@ -369,6 +370,7 @@
         },
         {
           "id": 333,
+          "uuid": "5e26217c-5a88-421b-81fc-0ce4f07f634a",
           "user": { "id": 333 },
           "created_at": "2010-01-01T02:00:00",
           "private_location": "1,2",
@@ -377,6 +379,7 @@
         },
         {
           "id": 4,
+          "uuid": "e29e68ca-0ecf-4c6b-8fd5-71a28603fb5d",
           "user": { "id": 333 },
           "created_at": "1500-01-01T05:00:00",
           "observed_on": "1500-01-01T05:00:00",
@@ -398,6 +401,7 @@
         },
         {
           "id": 5,
+          "uuid": "e60d4116-f327-4ce1-bd46-27048fdc68a0",
           "user": { "id": 333 },
           "taxon": {
             "id": 123,
@@ -414,6 +418,7 @@
         },
         {
           "id": 6,
+          "uuid": "e1aabcda-0d06-4454-8959-9b000e555610",
           "user": { "id": 333 },
           "geoprivacy": "private",
           "private_location": "1.234,1.234",
@@ -421,6 +426,7 @@
         },
         {
           "id": 7,
+          "uuid": "f88b97cf-6515-4f5b-9a94-5f484167e4a9",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
           "annotations": [
@@ -436,6 +442,7 @@
         },
         {
           "id": 8,
+          "uuid": "02ad4be1-9f21-41a9-82d3-444d6c1078da",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
           "annotations": [
@@ -451,6 +458,7 @@
         },
         {
           "id": 9,
+          "uuid": "dc223c38-8389-44cc-8d22-8a0e77a67cbf",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
           "annotations": [
@@ -473,6 +481,7 @@
         },
         {
           "id": 10,
+          "uuid": "b1aa0a03-3256-4913-aef4-c308ee51dd29",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
           "private_location": "1,2",
@@ -481,6 +490,7 @@
         },
         {
           "id": 11,
+          "uuid": "5adf654d-3aef-48ee-8fd3-48b4a1e2268d",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
           "private_location": "1,2",
@@ -489,16 +499,19 @@
         },
         {
           "id": 12,
+          "uuid": "95e01721-e302-4ac7-b395-f7e4384c76a3",
           "user": { "id": 5 },
           "identifier_user_ids": [ 121, 122 ]
         },
         {
           "id": 13,
+          "uuid": "97aaf567-3998-4a05-b743-a261b9e65031",
           "user": { "id": 5 },
           "identifier_user_ids": [ 121 ]
         },
         {
           "id": 14,
+          "uuid": "6d59a34c-efb3-498a-9aef-eb6ef60ac0ec",
           "user": { "id": 126, "login": "totally-trusting" },
           "description": "Observation by user 126 who trusts user 125",
           "private_location": "1,2",
@@ -506,6 +519,7 @@
         },
         {
           "id": 15,
+          "uuid": "dba1f134-f95c-45c2-8381-22b445cf73ef",
           "user": { "id": 5 },
           "description": "Observation of an obscured taxon",
           "private_location": "1,2",
@@ -514,6 +528,7 @@
         },
         {
           "id": 16,
+          "uuid": "0ae6884e-151e-4d5b-a916-889f01f95985",
           "user": { "id": 5 },
           "description": "Observation of an obscured taxon AND user geoprivacy",
           "private_location": "1,2",
@@ -523,6 +538,7 @@
         },
         {
           "id": 17,
+          "uuid": "450a7b9c-19f2-43ef-9cc9-38b0d6df9bde",
           "user": { "id": 5 },
           "description": "obs with a large positional_accuracy",
           "private_location": "1,2",
@@ -531,6 +547,7 @@
         },
         {
           "id": 18,
+          "uuid": "bf423b43-684a-4aed-bb0c-c8c5ded663c2",
           "user": { "id": 5 },
           "description": "obs with a small positional_accuracy",
           "private_location": "1,2",
@@ -539,6 +556,7 @@
         },
         {
           "id": 19,
+          "uuid": "6e2602c7-1529-4dce-bd62-32f9d0af62f2",
           "user": { "id": 5 },
           "description": "obs with no positional_accuracy",
           "private_location": "1,2",
@@ -546,6 +564,7 @@
         },
         {
           "id": 20,
+          "uuid": "50891b33-96d9-4e46-954d-6215a9ef8147",
           "description": "Has term 2",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
@@ -562,6 +581,7 @@
         },
         {
           "id": 21,
+          "uuid": "048a064f-efb1-4671-afeb-a2fae902df52",
           "description": "Has term 1 and 2",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
@@ -586,6 +606,7 @@
         },
         {
           "id": 22,
+          "uuid": "4307798e-d8d8-4030-8e08-60de0cbb8323",
           "description": "Observation field value of type numeric",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",
@@ -597,6 +618,7 @@
         },
         {
           "id": 23,
+          "uuid": "aded9e76-ba9a-427c-8346-5530a1dd4866",
           "description": "Observation field value of type taxon",
           "user": { "id": 5 },
           "created_at": "2001-06-01T01:00:00",

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -331,6 +331,7 @@
       "observation": [
         {
           "id": 1,
+          "uuid": "cabbd853-39c0-429c-86f1-b36063d3d475",
           "user": { "id": 123 },
           "created_at": "2015-12-31T00:00:00",
           "quality_grade": "research",

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -1,0 +1,23 @@
+const { expect } = require( "chai" );
+const fs = require( "fs" );
+const request = require( "supertest" );
+const app = require( "../../../openapi_app" );
+
+const fixtures = JSON.parse( fs.readFileSync( "schema/fixtures.js" ) );
+
+describe( "Observations", ( ) => {
+  describe( "show", ( ) => {
+    const fixtureObs = fixtures.elasticsearch.observations.observation[0];
+    it( "returns json", done => {
+      request( app ).get( `/v2/observations/${fixtureObs.id}` ).expect( res => {
+        expect( res.body.results[0].id ).to.eq( fixtureObs.id );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+    it( "returns the uuid when specified in the fields query param", done => {
+      request( app ).get( `/v2/observations/${fixtureObs.id}?fields=id,uuid` ).expect( res => {
+        expect( res.body.results[0].uuid ).to.eq( fixtureObs.uuid );
+      } ).expect( 200, done );
+    } );
+  } );
+} );

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -6,8 +6,8 @@ const app = require( "../../../openapi_app" );
 const fixtures = JSON.parse( fs.readFileSync( "schema/fixtures.js" ) );
 
 describe( "Observations", ( ) => {
+  const fixtureObs = fixtures.elasticsearch.observations.observation[0];
   describe( "show", ( ) => {
-    const fixtureObs = fixtures.elasticsearch.observations.observation[0];
     it( "returns json", done => {
       request( app ).get( `/v2/observations/${fixtureObs.uuid}` ).expect( res => {
         expect( res.body.results[0].uuid ).to.eq( fixtureObs.uuid );
@@ -33,6 +33,32 @@ describe( "Observations", ( ) => {
       request( app ).get( "/v2/observations?fields=user" ).expect( res => {
         expect( res.body.results[0].user ).to.not.be.undefined;
       } ).expect( 200, done );
+    } );
+    it( "should error when you POST with X-HTTP-Method-Override set to GET and a multipart/form-data payload", done => {
+      request( app )
+        .post( "/v2/observations" )
+        .send( `user_id=${fixtureObs.user.id}&fields=user` )
+        .set( "Content-Type", "multipart/form-data" )
+        .set( "X-HTTP-Method-Override", "GET" )
+        .expect( res => {
+          expect( res.body.status ).to.eq( 422 );
+        } )
+        .expect( 422, done );
+    } );
+    it( "should search when you POST with X-HTTP-Method-Overrid set to GET and a JSON payload", done => {
+      request( app )
+        .post( "/v2/observations" )
+        .set( "Content-Type", "application/json" )
+        .send( {
+          user_id: fixtureObs.user.id,
+          fields: ["user"]
+        } )
+        .set( "X-HTTP-Method-Override", "GET" )
+        .expect( res => {
+          expect( res.body.results[0].user.id ).to.eq( fixtureObs.user.id );
+        } )
+        .expect( "Content-Type", /json/ )
+        .expect( 200, done );
     } );
   } );
 } );

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -9,14 +9,29 @@ describe( "Observations", ( ) => {
   describe( "show", ( ) => {
     const fixtureObs = fixtures.elasticsearch.observations.observation[0];
     it( "returns json", done => {
-      request( app ).get( `/v2/observations/${fixtureObs.id}` ).expect( res => {
-        expect( res.body.results[0].id ).to.eq( fixtureObs.id );
+      request( app ).get( `/v2/observations/${fixtureObs.uuid}` ).expect( res => {
+        expect( res.body.results[0].uuid ).to.eq( fixtureObs.uuid );
       } ).expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );
     it( "returns the uuid when specified in the fields query param", done => {
-      request( app ).get( `/v2/observations/${fixtureObs.id}?fields=id,uuid` ).expect( res => {
+      request( app ).get( `/v2/observations/${fixtureObs.uuid}?fields=id,uuid` ).expect( res => {
         expect( res.body.results[0].uuid ).to.eq( fixtureObs.uuid );
+      } ).expect( 200, done );
+    } );
+  } );
+
+  describe( "search", ( ) => {
+    it( "returns json", done => {
+      request( app ).get( "/v2/observations" ).expect( res => {
+        expect( res.body.results[0].uuid ).to.not.be.undefined;
+      } )
+        .expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+    it( "returns user when specified in the fields query param", done => {
+      request( app ).get( "/v2/observations?fields=user" ).expect( res => {
+        expect( res.body.results[0].user ).to.not.be.undefined;
       } ).expect( 200, done );
     } );
   } );


### PR DESCRIPTION
This one seems a bit more controversial, both in requiring UUID-based retrieval for obs/show and in creating a v2 observations controller that currently wraps relevant methods from the v1 obs controller.