### PR TITLE
Include obs frequency scores even if no common ancestor was found

### DIFF
--- a/lib/controllers/v1/taxa_controller.js
+++ b/lib/controllers/v1/taxa_controller.js
@@ -1197,6 +1197,16 @@ TaxaController.nearby = async req => {
   // sort the nearby taxa by frequency and set limits and offsets
   const topCounts = _.reverse( _.sortBy( allCounts, "count" ) )
     .slice( offset, offset + perPage );
+
+  // If we were asked to include certain taxon IDs, let's make sure they don't
+  // get sliced off
+  if ( req.inat.includeTaxonIDs ) {
+    _.each( req.inat.includeTaxonIDs, taxonID => {
+      if ( groupedCounts[taxonID] ) {
+        topCounts.push( groupedCounts[taxonID] );
+      }
+    } );
+  }
   const localeOpts = util.localeOpts( req );
   const prepareTaxon = t => {
     t.prepareForResponse( localeOpts );


### PR DESCRIPTION
It *seems* like this is fixing a bug, because `TaxaController.includeTaxonInNearbyResults` definitely looks like it was written to ensure taxa in `req.inat.includeTaxonIDs` got included in nearby results, and so does `nearbyTaxonFrequenciesDB` in `ComputerVisionController`, but if I've removed some intended behavior, please let me know