### PR TITLE
Fix /photos endpoint

### DIFF
--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -450,7 +450,11 @@ InaturalistAPI.server = ( ) => {
   dfault( "delete", "/v1/observation_field_values/:id", ObservationFieldValuesController.delete );
 
   // Photos
-  dfault( "post", "/v1/photos", PhotosController.create );
+  dfault( "post", "/v1/photos", PhotosController.create, {
+    routeHandler: upload.fields( [
+      { name: "file", maxCount: 1 }
+    ] )
+  } );
 
   // Sounds
   dfault( "post", "/v1/sounds", SoundsController.create );

--- a/lib/views/swagger_v1.yml.ejs
+++ b/lib/views/swagger_v1.yml.ejs
@@ -1196,6 +1196,25 @@ paths:
       responses:
         200:
           description: OK
+  /photos:
+    post:
+      summary: Photo Create
+      description: |
+        Create a photo
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: file
+          in: formData
+          description: The photo
+          type: file
+      tags:
+        - Photos
+      security:
+        - api_token: []
+      responses:
+        200:
+          description: OK
   /places/{id}:
     get:
       summary: Place Details


### PR DESCRIPTION
Currently the /photos endpoint doesn't work and isn't documented. This fixes that.

"Doesn't work" means the file is received by the NodeJS API and written to the temp filesystem, but it wasn't included in the request that is then sent to the Rails server.

This PR is important because it lets third party clients follow the same flow as the iNat webpage by uploading photos first, then referencing them as `local_photos` in the obs upload.