### PR TITLE
Delay users/me if user not found

### DIFF
--- a/lib/controllers/v1/users_controller.js
+++ b/lib/controllers/v1/users_controller.js
@@ -2,6 +2,7 @@ const _ = require( "lodash" );
 const squel = require( "squel" );
 const { users } = require( "inaturalistjs" );
 const InaturalistAPI = require( "../../inaturalist_api" );
+const util = require( "../../util" );
 const Place = require( "../../models/place" );
 const Project = require( "../../models/project" );
 const Site = require( "../../models/site" );
@@ -46,10 +47,18 @@ const UsersController = class UsersController {
     if ( !req.userSession ) {
       throw new Error( 401 );
     }
-    const user = await User.findInES( req.userSession.user_id );
+    let user = await User.findInES( req.userSession.user_id );
     if ( !user ) {
-      // { error: "Unknown user", status: 422 };
-      throw new Error( 422 );
+      // In case this user was just created, wait a second for the index to
+      // catch up
+      util.sleep( 1 );
+      user = await User.findInES( req.userSession.user_id );
+      if ( !user ) {
+        const e = new Error( );
+        e.status = 404;
+        e.custom_message = "User does not exist";
+        throw e;
+      }
     }
     const userDBAttrs = await User.privateDbAttributesFromLogin( user.login );
     Object.assign( user, userDBAttrs );

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -91,7 +91,7 @@ const User = class User extends Model {
   }
 
   static async findInES( idOrLogin ) {
-    const lookedUpUser = await User.findByLoginOrID( idOrLogin );
+    let lookedUpUser = await User.findByLoginOrID( idOrLogin );
     if ( !lookedUpUser ) { return null; }
     const query = { body: { query: { term: { id: lookedUpUser.id } } } };
     const results = await esClient.search( "users", query );

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ const md5 = require( "md5" );
 const moment = require( "moment" );
 const config = require( "../config" );
 const Logstasher = require( "./logstasher" );
+const nodeUtil = require( "util" );
 
 const environment = process.env.NODE_ENV || config.environment;
 
@@ -476,6 +477,8 @@ const util = class util {
       }
     }, _.isArray( obj ) ? [] : {} );
   }
+
+  static sleep = nodeUtil.promisify( setTimeout );
 };
 
 util.iucnValues = {


### PR DESCRIPTION
The intent here is to wait for the index to refresh if a user wasn't found and then try again to deal with situations where the user was just created. This stemmed from a problem @alexshepard was reporting in the iPhone app where he was creating a new user account and then hitting users/me to retrieve its node API representation but getting nothing, even though the user had been created.

There's a potential performance problem if we get a ton of requests for users who don't exist, so I wanted to run this by you before merging, @pleary.