### PR TITLE
Non-human exclusion

### DIFF
--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -337,6 +337,7 @@ const ComputervisionController = class ComputervisionController {
     if ( req.inat.visionStats ) {
       return { results: top10, common_ancestor: commonAncestor };
     }
+    const viewerIsAdmin = req.userSession && req.userSession.isAdmin;
     req.inat.taxonPhotos = true;
     req.inat.taxonAncestries = true;
     const response = await TaxaController.speciesCountsResponse( req, top10, { } );
@@ -347,14 +348,14 @@ const ComputervisionController = class ComputervisionController {
     const topResult = response.results[0];
     const topResultIsHuman = topResult && Taxon.homo
       && topResult.taxon.ancestor_ids.indexOf( Taxon.homo.id ) >= 0;
-    if ( topResultIsHuman && response.results.length > 1 ) {
+    if ( viewerIsAdmin && topResultIsHuman && response.results.length > 1 ) {
       const topResultDiff = topResult.combined_score - response.results[1].combined_score;
       if ( topResultDiff >= 20 ) {
         response.results = [topResult];
       }
     }
-    // there is no common ancestor, or the common ancestor is Humans,
-    // so skip it and don't recommend any common ancestors
+    // There is no common ancestor, or the common ancestor is Humans, so skip it
+    // and don't recommend any common ancestors
     if (
       !commonAncestor
       || !commonAncestor.taxon
@@ -365,7 +366,7 @@ const ComputervisionController = class ComputervisionController {
       // suggesting a person is a non-human
       const humanResult = Taxon.homo
         && _.find( response.results, r => r.taxon.ancestor_ids.indexOf( Taxon.homo.id ) >= 0 );
-      if ( humanResult && response.results.length > 1 ) {
+      if ( viewerIsAdmin && humanResult && response.results.length > 1 ) {
         response.results = [];
       }
       return response;

--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -214,7 +214,7 @@ const ComputervisionController = class ComputervisionController {
     InaturalistAPI.setPerPage( req, { default: 10, max: 100 } );
     const imageScores = await ComputervisionController.scoreImagePath( uploadPath, req );
     let scores = _.filter( imageScores, s => ( s.count > 0 ) );
-    if ( req.body.taxon_id ) {
+    if ( parseInt( req.body.taxon_id, 0 ) > 0 ) {
       await ComputervisionController.cacheAllTaxonAncestries( );
       if ( !TFServingTaxonDescendants[req.body.taxon_id] ) {
         return InaturalistAPI.basicResponse( req );
@@ -344,10 +344,30 @@ const ComputervisionController = class ComputervisionController {
       r.combined_score = r.count;
       delete r.count;
     } );
+    const topResult = response.results[0];
+    const topResultIsHuman = topResult && Taxon.homo
+      && topResult.taxon.ancestor_ids.indexOf( Taxon.homo.id ) >= 0;
+    if ( topResultIsHuman && response.results.length > 1 ) {
+      const topResultDiff = topResult.combined_score - response.results[1].combined_score;
+      if ( topResultDiff >= 20 ) {
+        response.results = [topResult];
+      }
+    }
     // there is no common ancestor, or the common ancestor is Humans,
     // so skip it and don't recommend any common ancestors
-    if ( !commonAncestor || !commonAncestor.taxon
-      || ( Taxon.homo && commonAncestor.taxon.id === Taxon.homo.id ) ) {
+    if (
+      !commonAncestor
+      || !commonAncestor.taxon
+      || ( Taxon.homo && commonAncestor.taxon.id === Taxon.homo.id )
+    ) {
+      // If human is in the results but the results are spread out enough that
+      // we didn't choose a common ancestors, just completely bail to avoid
+      // suggesting a person is a non-human
+      const humanResult = Taxon.homo
+        && _.find( response.results, r => r.taxon.ancestor_ids.indexOf( Taxon.homo.id ) >= 0 );
+      if ( humanResult && response.results.length > 1 ) {
+        response.results = [];
+      }
       return response;
     }
     // If we have a common ancestor, we need to reload it b/c it might have


### PR DESCRIPTION
Attempts to decrease opportunities for identifying humans as non-humans using automated suggestions by

1. Only suggesting human when human is the top result and is 20 points higher than the second result
2. Only suggesting human when there no common ancestor was found (i.e. scores are spread out instead of strongly favoring a higher-level taxon) and human is among the suggestions

Currently implemented as an admin-only test.