### PR TITLE
Added an endpoint to log errors reported by clients

### DIFF
--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -311,6 +311,23 @@ InaturalistAPI.server = ( ) => {
     defaultTTL: -1
   } );
 
+  // Like GET /v1/log, but intended to log errors from the client in the POST
+  // body. See Logstasher.afterRequestPayload for body parsing logic.
+  dfault( "post", "/v1/log", req => {
+    // Checking against the origin in the config will restrict logging behavior
+    // to a single domain. If we want to support this on partner sites, we might
+    // want to use an app token, but that will mean embedding a working app
+    // token on all pages
+    const pattern = new RegExp( `^${_.escapeRegExp( config.apiURL )}` );
+    if ( req.headers.origin && req.headers.origin.match( pattern ) ) {
+      req._logClientError = true;
+      return {};
+    }
+    throw util.httpError( 401, "Unauthorized" );
+  }, {
+    defaultTTL: -1
+  } );
+
   const allPreloads = { userBlocks: true, curatedProjects: true, localeDefaults: true };
   // Observations
   dfault( "post", "/v1/observations", ObservationsController.create );

--- a/lib/logstasher.js
+++ b/lib/logstasher.js
@@ -100,6 +100,13 @@ const Logstasher = class Logstasher {
       payload.tile_cache_hash = Logstasher.tileCacheParams( req, { string: true } );
       payload.tile_cache_zoom_hash = Logstasher.tileCacheZoomParams( req, { string: true } );
     }
+    // Parse the body for an attempt to log a client-side error
+    if ( req._logClientError && req.body ) {
+      payload.error_type = req.body.error_type;
+      payload.error_message = req.body.error_message;
+      payload.backtrace = req.body.backtrace;
+      payload.subtype = "ClientError";
+    }
     return payload;
   }
 


### PR DESCRIPTION
Uses existing logstash fields and sets the `subtype` to `ClientError`. Leaves the `body_string` intact even though its values are parsed and placed elsewhere, which might not be great for storage but does preserve a record of what was actually submitted.