### PR TITLE
Document ident_user_id search parameter for GET /observations

### DIFF
--- a/lib/views/_observation_search_params_v1.yml.ejs
+++ b/lib/views/_observation_search_params_v1.yml.ejs
@@ -43,6 +43,7 @@
         - $ref: "#/parameters/taxon_name"
         - $ref: "#/parameters/user_id"
         - $ref: "#/parameters/user_login"
+        - $ref: "#/parameters/ident_user_id"
         - $ref: "#/parameters/day"
         - $ref: "#/parameters/month"
         - $ref: "#/parameters/year"


### PR DESCRIPTION
This recently came up in [this forum thread](https://forum.inaturalist.org/t/tool-for-exporting-inaturalist-data-to-irecord-or-elsewhere/19160/31). It appears that GET /observations accepts an `ident_user_id` parameter, and it was already added to the parameter definitions in the Swagger spec, but wasn't referenced by GET /observations.