### PR TITLE
Use requested place bounding box instead of obs extent for return_bounds

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -107,13 +107,32 @@ ObservationsController.searchCacheWrapper = async req => (
 
 ObservationsController.search = async req => {
   if ( req.query.return_bounds === "true" ) {
-    req.query.aggs = {
-      bbox: {
-        geo_bounds: {
-          field: "location"
-        }
+    // If we've been asked to return the bounds but also to return obs in a
+    // place, assume that the bounds are the bounding box of the place and not
+    // the bounding box that contains the observations in that place. This
+    // changes the meaning of return_bounds, but will probably satisfy most
+    // cases and might be more performative
+    if ( req.query.place_id ) {
+      const place = await Place.findByID( req.query.place_id, { fields: ["bounding_box_geojson"] } );
+      if ( place.bounding_box_geojson ) {
+        req.inat = req.inat || {};
+        req.inat.impliedBounds = {
+          swlat: place.bounding_box_geojson.coordinates[0][0][1],
+          swlng: place.bounding_box_geojson.coordinates[0][0][0],
+          nelat: place.bounding_box_geojson.coordinates[0][2][1],
+          nelng: place.bounding_box_geojson.coordinates[0][2][0]
+        };
       }
-    };
+    }
+    if ( !req.inat || !req.inat.impliedBounds ) {
+      req.query.aggs = {
+        bbox: {
+          geo_bounds: {
+            field: "location"
+          }
+        }
+      };
+    }
   }
   const data = await ObservationsController.resultsForRequest( req );
   const localeOpts = util.localeOpts( req );
@@ -315,6 +334,8 @@ ObservationsController.prepareElasticDataForReponse = ( data, req ) => {
       nelat: data.aggregations.bbox.bounds.top_left.lat,
       nelng: data.aggregations.bbox.bounds.bottom_right.lon
     };
+  } else if ( req.inat.impliedBounds ) {
+    response.total_bounds = req.inat.impliedBounds;
   }
   response.page = Number( req.elastic_query.page );
   response.per_page = Number( req.elastic_query.per_page );

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -334,7 +334,7 @@ ObservationsController.prepareElasticDataForReponse = ( data, req ) => {
       nelat: data.aggregations.bbox.bounds.top_left.lat,
       nelng: data.aggregations.bbox.bounds.bottom_right.lon
     };
-  } else if ( req.inat.impliedBounds ) {
+  } else if ( req.inat && req.inat.impliedBounds ) {
     response.total_bounds = req.inat.impliedBounds;
   }
   response.page = Number( req.elastic_query.page );

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -112,15 +112,14 @@ ObservationsController.search = async req => {
     // the bounding box that contains the observations in that place. This
     // changes the meaning of return_bounds, but will probably satisfy most
     // cases and might be more performative
-    if ( req.query.place_id ) {
-      const place = await Place.findByID( req.query.place_id, { fields: ["bounding_box_geojson"] } );
-      if ( place.bounding_box_geojson ) {
+    if ( req.inat.place ) {
+      if ( req.inat.place.bounding_box_geojson ) {
         req.inat = req.inat || {};
         req.inat.impliedBounds = {
-          swlat: place.bounding_box_geojson.coordinates[0][0][1],
-          swlng: place.bounding_box_geojson.coordinates[0][0][0],
-          nelat: place.bounding_box_geojson.coordinates[0][2][1],
-          nelng: place.bounding_box_geojson.coordinates[0][2][0]
+          swlat: req.inat.place.bounding_box_geojson.coordinates[0][0][1],
+          swlng: req.inat.place.bounding_box_geojson.coordinates[0][0][0],
+          nelat: req.inat.place.bounding_box_geojson.coordinates[0][2][1],
+          nelng: req.inat.place.bounding_box_geojson.coordinates[0][2][0]
         };
       }
     }

--- a/lib/models/place.js
+++ b/lib/models/place.js
@@ -5,14 +5,14 @@ const pgClient = require( "../pg_client" );
 const Model = require( "./model" );
 
 const Place = class Place extends Model {
-  static async findByID( id ) {
+  static async findByID( id, options = {} ) {
     if ( !Number( id ) ) {
       throw new Error( "invalid place_id" );
     }
     const response = await esClient.search( "places", {
       body: {
         query: { term: { id } },
-        _source: ["id", "name", "display_name", "place_type", "ancestor_place_ids"]
+        _source: options.fields || ["id", "name", "display_name", "place_type", "ancestor_place_ids"]
       }
     } );
     return response.hits.hits[0] ? response.hits.hits[0]._source : null;


### PR DESCRIPTION
Calculating the bounds is slow, and most cases of searching for obs in a place only need a bounding box for the place, not the obs, so this might save some ES time without too much impact.

This will change the prior behavior, though. E.g. if you are searching for bats in Botswana and there are only a handful of bat obs in the northwestern part of the country, you would get back a bounding box focusing only on those obs. With this change, you would get back a bounding box that includes all of Botswana.

Related to https://github.com/inaturalist/inaturalist/issues/2996