### PR TITLE
Tidy jwt secret fallbacks and example config

### DIFF
--- a/config.js.travis
+++ b/config.js.travis
@@ -22,6 +22,6 @@ module.exports = {
     tensorappURL: "http://localhost:6006"
   },
   debug: true,
-  jwtSecret: "jwtSecret",
-  jwtApplicationSecret: "jwtApplicationSecret"
+  jwtSecret: "secret",
+  jwtApplicationSecret: "application_secret"
 }

--- a/config_example.js
+++ b/config_example.js
@@ -46,8 +46,8 @@ module.exports = {
   debug: true,
   staticImagePrefix: "http://localhost:3000/attachments/",
   userImagePrefix: "/attachments/users/icons/",
-  jwtSecret: "jwtSecret",
-  jwtApplicationSecret: "jwtApplicationSecret",
+  jwtSecret: "secret",
+  jwtApplicationSecret: "application_secret",
   imageProcesing: {
     // Path to a file listing the taxonomy used in the computer vision model
     taxaFilePath: "",

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -93,7 +93,7 @@ InaturalistAPI.validateApplication = ( req, res, next ) => {
     return;
   }
   if ( req.headers.authorization ) {
-    jwt.verify( req.headers.authorization, config.jwtApplicationSecret || "secret",
+    jwt.verify( req.headers.authorization, config.jwtApplicationSecret || "application_secret",
       { algorithms: ["HS512"] }, ( err, payload ) => {
         if ( !err ) {
           req.applicationSession = payload;

--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -435,7 +435,7 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
       return Promise.resolve( true );
     }
     const token = _.last( req.headers.authorization.split( /\s+/ ) );
-    return jwt.verify( token, config.jwtApplicationSecret || "secret",
+    return jwt.verify( token, config.jwtApplicationSecret || "application_secret",
       { algorithms: ["HS512"] }, ( err, payload ) => {
         if ( required === "required" && err ) throw jwtInvalidError;
         if ( payload && payload.application ) {

--- a/test/integration/v1/geoip_lookup.js
+++ b/test/integration/v1/geoip_lookup.js
@@ -23,7 +23,7 @@ describe( "geoip_lookup", ( ) => {
     } );
 
     it( "returns geoip responses", done => {
-      const token = jwt.sign( { application: "whatever" }, config.jwtApplicationSecret || "appsecret",
+      const token = jwt.sign( { application: "whatever" }, config.jwtApplicationSecret || "application_secret",
         { algorithm: "HS512" } );
       request( app ).get( "/v1/geoip_lookup?ip=128.128.128.128" )
         .set( "Authorization", token )

--- a/test/integration/v2/computervision.js
+++ b/test/integration/v2/computervision.js
@@ -36,7 +36,7 @@ describe( "Computervision", ( ) => {
         .expect( 200, done );
     } );
     it( "works with an application token", done => {
-      const token = jwt.sign( { application: "whatever" }, config.jwtApplicationSecret || "appsecret",
+      const token = jwt.sign( { application: "whatever" }, config.jwtApplicationSecret || "application_secret",
         { algorithm: "HS512" } );
       request( app ).get( url )
         .set( "Authorization", token )
@@ -55,7 +55,7 @@ describe( "Computervision", ( ) => {
         .expect( 401, done );
     } );
     it( "should fail without a token that specifies a user or an application", done => {
-      const token = jwt.sign( { thisIs: "the way" }, config.jwtApplicationSecret || "secret",
+      const token = jwt.sign( { thisIs: "the way" }, config.jwtApplicationSecret || "application_secret",
         { algorithm: "HS512" } );
       request( app ).get( url )
         .set( "Authorization", token )


### PR DESCRIPTION
Minor tidy up in order to consolidate fallbacks and example configs.

Equivalent change planned for inaturalist `config.yml.example`

As discussed briefly in https://github.com/inaturalist/inaturalist/pull/3169#discussion_r688461193