### PR TITLE
Include mention updates in /observations/updates for following

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -1183,7 +1183,6 @@ ObservationsController.updates = async req => {
   req.query.page = Number( req.query.page ) || 1;
   const updatesFilters = [
     { term: { resource_type: "Observation" } },
-    { term: { notification: "activity" } },
     { terms: { notifier_type: ["Identification", "Comment"] } },
     { term: { subscriber_ids: req.userSession.user_id } }
   ];
@@ -1207,9 +1206,20 @@ ObservationsController.updates = async req => {
     updatesFilters.push( {
       term: { resource_owner_id: req.userSession.user_id }
     } );
+    updatesFilters.push( {
+      term: { notification: "activity" }
+    } );
   } else if ( req.query.observations_by === "following" ) {
     inverseFilters.push( {
       term: { resource_owner_id: req.userSession.user_id }
+    } );
+    // Include mentions in observations in "following" content
+    updatesFilters.push( {
+      terms: { notification: ["activity", "mention"] }
+    } );
+  } else {
+    updatesFilters.push( {
+      term: { notification: "activity" }
     } );
   }
   const response = await esClient.connection.search( {


### PR DESCRIPTION
Might not be the best idea as it adds mention updates to /observations/updates?observations_by=following when they weren't there before, and technically includes updates about observations the user is not following, but it's a relatively simple way to get mentions into the apps.

https://github.com/inaturalist/iNaturalistAndroid/issues/1133 should be completed and released before merging.