### PR TITLE
Ensure description and other fields get returned for /v2/users/:id

### DIFF
--- a/lib/controllers/v2/users_controller.js
+++ b/lib/controllers/v2/users_controller.js
@@ -1,10 +1,50 @@
 const { users } = require( "inaturalistjs" );
+const User = require( "../../models/user" );
 const InaturalistAPI = require( "../../inaturalist_api" );
+const ctrlv1 = require( "../v1/taxa_controller" );
+const { httpError } = require( "../../util" );
 
 const updateSession = async req => {
   await InaturalistAPI.iNatJSWrap( users.update_session, req );
 };
 
+const show = async req => {
+  InaturalistAPI.setPerPage( req, { default: 10, max: 100 } );
+  const user = await User.find( req.params.id, {
+    fields: [
+      "created_at",
+      "description",
+      "icon",
+      "id",
+      "identifications_count",
+      "journal_posts_count",
+      "login",
+      "monthly_supporter",
+      "name",
+      "observations_count",
+      "orcid",
+      "roles",
+      "site",
+      "spam",
+      "species_count",
+      "suspended",
+      "updated_at",
+      "uuid"
+    ]
+  } );
+  if ( !user ) {
+    throw httpError( 404, "User does not exist" );
+  }
+  return InaturalistAPI.resultsHash( {
+    total: 1,
+    per_page: req.query.per_page,
+    page: req.query.page,
+    results: [user]
+  } );
+};
+
 module.exports = {
+  show,
+  update: ctrlv1.update,
   updateSession
 };

--- a/lib/controllers/v2/users_controller.js
+++ b/lib/controllers/v2/users_controller.js
@@ -21,6 +21,7 @@ const show = async req => {
       "id",
       "identifications_count",
       "journal_posts_count",
+      "last_active",
       "login",
       "monthly_supporter",
       "name",

--- a/lib/controllers/v2/users_controller.js
+++ b/lib/controllers/v2/users_controller.js
@@ -1,4 +1,7 @@
+const _ = require( "lodash" );
 const { users } = require( "inaturalistjs" );
+const pgClient = require( "../../pg_client" );
+const esClient = require( "../../es_client" );
 const User = require( "../../models/user" );
 const InaturalistAPI = require( "../../inaturalist_api" );
 const ctrlv1 = require( "../v1/taxa_controller" );
@@ -43,7 +46,52 @@ const show = async req => {
   } );
 };
 
+const index = async req => {
+  InaturalistAPI.setPerPage( req, { default: 10, max: 100 } );
+  const filters = [];
+  if ( req.query.following ) {
+    const followingUser = await User.findByLoginOrID( req.query.following );
+    if ( !followingUser ) {
+      throw httpError( 422, `User ${req.query.following} does not exist` );
+    }
+    const { rows: followers } = await pgClient.connection.query(
+      `SELECT user_id FROM friendships WHERE friend_id = ${followingUser.id}`
+    );
+    filters.push( esClient.termFilter( "id", _.map( followers, f => f.user_id ) ) );
+  }
+  if ( req.query.followed_by ) {
+    const followedByUser = await User.findByLoginOrID( req.query.followed_by );
+    if ( !followedByUser ) {
+      throw httpError( 422, `User ${req.query.followed_by} does not exist` );
+    }
+    const { rows: followees } = await pgClient.connection.query(
+      `SELECT friend_id FROM friendships WHERE user_id = ${followedByUser.id}`
+    );
+    filters.push( esClient.termFilter( "id", _.map( followees, f => f.friend_id ) ) );
+  }
+  const response = await esClient.connection.search( {
+    preference: global.config.elasticsearch.preference,
+    index: `${process.env.NODE_ENV || global.config.environment}_users`,
+    body: {
+      query: {
+        bool: {
+          filter: filters
+        }
+      },
+      sort: { id: "asc" },
+      size: req.query.per_page
+    }
+  } );
+  return InaturalistAPI.resultsHash( {
+    total: response.hits.total.value,
+    per_page: req.query.per_page,
+    page: Number( req.query.page ),
+    results: _.map( response.hits.hits, h => new User( h._source ) )
+  } );
+};
+
 module.exports = {
+  index,
   show,
   update: ctrlv1.update,
   updateSession

--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -362,8 +362,12 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
     if ( fieldsToReturn.all ) {
       _.each( itemSchema.properties, ( v, k ) => {
         const propertySchema = InaturalistAPIV2.resolveSchema( req, v );
-        prunedItem[k] = InaturalistAPIV2.applyFieldSelectionToItem( req,
-          item[k], { all: true }, propertySchema );
+        prunedItem[k] = InaturalistAPIV2.applyFieldSelectionToItem(
+          req,
+          item[k],
+          { all: true },
+          propertySchema
+        );
       } );
     } else {
       // loop through the requested fields
@@ -372,8 +376,12 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
         const fieldSchema = itemSchema.properties[k];
         if ( item[k] !== undefined && fieldSchema ) {
           const propertySchema = InaturalistAPIV2.resolveSchema( req, fieldSchema );
-          prunedItem[k] = InaturalistAPIV2.applyFieldSelectionToItem( req,
-            item[k], v, propertySchema );
+          prunedItem[k] = InaturalistAPIV2.applyFieldSelectionToItem(
+            req,
+            item[k],
+            v,
+            propertySchema
+          );
         }
       } );
     }

--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -1,7 +1,5 @@
 const _ = require( "lodash" );
 const moment = require( "moment-timezone" );
-const squel = require( "safe-squel" );
-const pgClient = require( "../pg_client" );
 
 moment.tz.setDefault( "UTC" );
 

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -4,6 +4,7 @@ const esClient = require( "../es_client" );
 const pgClient = require( "../pg_client" );
 const util = require( "../util" );
 const Model = require( "./model" );
+const Site = require( "./site" );
 
 // This is a not-great duplication of logic in the Rails app where this model
 // really lives, but this saves us an additional HTTP request
@@ -65,11 +66,50 @@ const PREFERRED_PREFS = [
   "sound_license"
 ];
 
+const ES_ONLY_FIELDS = [
+  "icon",
+  "orcid",
+  "roles",
+  "spam",
+  "suspended"
+];
+
 const User = class User extends Model {
   constructor( attrs ) {
     super( attrs );
     this.icon_url = User.iconUrl( this );
     this.orcid = this.orcid ? `https://orcid.org/${this.orcid}` : null;
+  }
+
+  static async find( id, options = {} ) {
+    if ( _.isEmpty( id ) ) { return null; }
+    const fields = options.fields || User.returnFields;
+    const dbFields = _.difference( fields, ES_ONLY_FIELDS );
+    const query = squel.select( )
+      .from( User.tableName )
+      .where( "id = ?", id );
+    if ( dbFields.indexOf( "monthly_supporter" ) >= 0 ) {
+      _.pull( dbFields, "monthly_supporter" );
+      query.field(
+        "donorbox_plan_type = 'monthly' AND donorbox_plan_status = 'active'",
+        "monthly_supporter"
+      );
+    }
+    if ( fields.indexOf( "site" ) ) {
+      _.pull( dbFields, "site" );
+    }
+    query.fields( dbFields );
+    const { rows } = await pgClient.connection.query( query.toString( ) );
+    const dbResponse = rows[0];
+    if ( _.isEmpty( dbResponse ) ) { return null; }
+    const esResponse = await User.findInES( id );
+    if ( _.isEmpty( esResponse ) ) { return null; }
+    const user = new User( { ...dbResponse, ...esResponse } );
+    if ( fields.indexOf( "site" ) && dbResponse.site_id ) {
+      user.site = new Site( Site.dbAttributes( dbResponse.site_id ) );
+      delete user.site_id;
+    }
+    return user;
   }
 
   static async privateDbAttributesFromLogin( login ) {

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -194,6 +194,8 @@ const User = class User extends Model {
     const asInt = Number( login );
     if ( asInt ) {
       query = query.where( "id = ? OR login = '?'", asInt, asInt );
+    } else if ( util.isUUID( login ) ) {
+      query = query.where( "uuid = ?", login );
     } else {
       query = query.where( "lower(login) = ?", login.toLowerCase( ) );
     }

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -97,6 +97,11 @@ const User = class User extends Model {
     }
     if ( fields.indexOf( "site" ) ) {
       _.pull( dbFields, "site" );
+      dbFields.push( "site_id" );
+    }
+    if ( fields.indexOf( "last_active" ) ) {
+      _.pull( dbFields, "last_active" );
+      query.field( "last_active::text", "last_active" );
     }
     query.fields( dbFields );
     const { rows } = await pgClient.connection.query( query.toString( ) );
@@ -106,7 +111,10 @@ const User = class User extends Model {
     if ( _.isEmpty( esResponse ) ) { return null; }
     const user = new User( { ...dbResponse, ...esResponse } );
     if ( fields.indexOf( "site" ) && dbResponse.site_id ) {
-      user.site = new Site( Site.dbAttributes( dbResponse.site_id ) );
+      const siteAttrs = await Site.dbAttributes( [dbResponse.site_id] );
+      if ( siteAttrs && siteAttrs.length > 0 ) {
+        user.site = siteAttrs[0];
+      }
       delete user.site_id;
     }
     return user;

--- a/openapi/paths/v2/observations/{uuid}/quality/{metric}.js
+++ b/openapi/paths/v2/observations/{uuid}/quality/{metric}.js
@@ -27,7 +27,16 @@ module.exports = sendWrapper => {
         Joi.string( )
           .label( "metric" )
           .required( )
-          .description( "The metric being voted on" )
+          .description( `
+            The metric being voted on.
+
+            date: Whether or not the date seems accurate.
+            evidence: Whether the media presents evidence for the presence of the organism.
+            location: Whether the location seems accurate.
+            needs_id: Whether the observation should remain in the Needs ID category.
+            recent: Whether the evidence demonstrates that the organism was present recently.
+            wild: Whether the individual organism was where and when it was without human intervention.
+          `.replace( /\s+/m, " " ) )
           .meta( { in: "path" } )
           .valid(
             "date",

--- a/openapi/paths/v2/users.js
+++ b/openapi/paths/v2/users.js
@@ -28,7 +28,7 @@ module.exports = sendWrapper => {
     parameters,
     responses: {
       200: {
-        description: "A list of places",
+        description: "A list of users",
         content: {
           "application/json": {
             schema: {

--- a/openapi/paths/v2/users.js
+++ b/openapi/paths/v2/users.js
@@ -1,0 +1,46 @@
+const _ = require( "lodash" );
+const usersIndexSchema = require( "../../schema/request/users_index" );
+const transform = require( "../../joi_to_openapi_parameter" );
+const UsersController = require( "../../../lib/controllers/v2/users_controller" );
+
+module.exports = sendWrapper => {
+  async function GET( req, res ) {
+    const results = await UsersController.index( req );
+    sendWrapper( req, res, null, results );
+  }
+
+  const parameters = [
+    {
+      in: "header",
+      name: "X-HTTP-Method-Override",
+      schema: {
+        type: "string"
+      },
+      example: "GET"
+    }
+  ].concat( _.map( usersIndexSchema.$_terms.keys, child => (
+    transform( child.schema.label( child.key ) )
+  ) ) );
+
+  GET.apiDoc = {
+    tags: ["Users"],
+    summary: "List users",
+    parameters,
+    responses: {
+      200: {
+        description: "A list of places",
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ResultsUsers"
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return {
+    GET
+  };
+};

--- a/openapi/paths/v2/users/me.js
+++ b/openapi/paths/v2/users/me.js
@@ -1,6 +1,5 @@
 const UsersController = require( "../../../../lib/controllers/v1/users_controller" );
 
-
 module.exports = sendWrapper => {
   async function GET( req, res ) {
     const results = await UsersController.me( req );
@@ -19,7 +18,7 @@ module.exports = sendWrapper => {
         content: {
           "application/json": {
             schema: {
-              $ref: "#/components/schemas/ResultsUsers"
+              $ref: "#/components/schemas/ResultsUsersMe"
             }
           }
         }

--- a/openapi/paths/v2/users/{id}.js
+++ b/openapi/paths/v2/users/{id}.js
@@ -2,7 +2,7 @@ const Joi = require( "joi" );
 const j2s = require( "joi-to-swagger" );
 const usersUpdateSchema = require( "../../../schema/request/users_update_multipart" );
 const transform = require( "../../../joi_to_openapi_parameter" );
-const UsersController = require( "../../../../lib/controllers/v1/users_controller" );
+const UsersController = require( "../../../../lib/controllers/v2/users_controller" );
 
 module.exports = sendWrapper => {
   async function GET( req, res ) {

--- a/openapi/schema/request/users_index.js
+++ b/openapi/schema/request/users_index.js
@@ -1,0 +1,23 @@
+const Joi = require( "joi" );
+
+module.exports = Joi.object( ).keys( {
+  fields: Joi.any( ),
+  page: Joi.number( ).integer( ).min( 1 ),
+  per_page: Joi.number( ).integer( ).min( 1 ).max( 200 ),
+  following: Joi
+    .alternatives( ).try(
+      Joi.number( ).integer( ).min( 1 ),
+      Joi.string( ),
+      Joi.string( ).guid( )
+    )
+    .example( "1234" )
+    .description( "Show users following this user, specified by sequential ID, username, or UUID" ),
+  followed_by: Joi
+    .alternatives( ).try(
+      Joi.number( ).integer( ).min( 1 ),
+      Joi.string( ),
+      Joi.string( ).guid( )
+    )
+    .example( "1234" )
+    .description( "Show users followed by this user, specified by sequential ID, username, or UUID" )
+} );

--- a/openapi/schema/response/private_user.js
+++ b/openapi/schema/response/private_user.js
@@ -1,0 +1,55 @@
+const Joi = require( "joi" );
+const user = require( "./user" );
+
+module.exports = user.append( {
+  activity_count: Joi.number( ).integer( ),
+  blocked_user_ids: Joi.array( ).items(
+    Joi.number( ).integer( )
+  ).valid( null ),
+  email: Joi.string( ).valid( null ),
+  locale: Joi.string( ).valid( null ),
+  login: Joi.string( ),
+  muted_user_ids: Joi.array( ).items(
+    Joi.number( ).integer( )
+  ).valid( null ),
+  place_id: Joi.number( ).integer( ).valid( null ),
+  preferences: Joi.object( ).keys( {
+    prefers_community_taxa: Joi.boolean( ),
+    prefers_observation_fields_by: Joi.string( )
+      .description( "Allows this kind of user to add observation field values to their observations" ),
+    prefers_project_addition_by: Joi.string( )
+      .description( "Allows this kind of user to add their observations to projects" ),
+    prefers_common_names: Joi.boolean( )
+      .description( "Prefers to view common names" ),
+    prefers_scientific_name_first: Joi.boolean( )
+      .description( "Prefers to view scientific names before common names" )
+  } ).unknown( false ),
+  prefers_automatic_taxonomic_changes: Joi.boolean( ).valid( null ),
+  prefers_comment_email_notification: Joi.boolean( ).valid( null ),
+  prefers_common_names: Joi.boolean( ).valid( null ),
+  prefers_community_taxa: Joi.boolean( ).valid( null ),
+  prefers_identification_email_notification: Joi.boolean( ).valid( null ),
+  prefers_mention_email_notification: Joi.boolean( ).valid( null ),
+  prefers_message_email_notification: Joi.boolean( ).valid( null ),
+  prefers_monthly_supporter_badge: Joi.boolean( ).valid( null ),
+  prefers_no_email: Joi.boolean( ).valid( null ),
+  prefers_no_tracking: Joi.boolean( ).valid( null ),
+  preferred_observation_fields_by: Joi.string( ).valid( null ),
+  preferred_observation_license: Joi.string( ).valid( null ),
+  preferred_photo_license: Joi.string( ).valid( null ),
+  prefers_project_added_your_observation_email_notification: Joi.boolean( ).valid( null ),
+  preferred_project_addition_by: Joi.string( ).valid( null ),
+  prefers_project_curator_change_email_notification: Joi.boolean( ).valid( null ),
+  prefers_project_journal_post_email_notification: Joi.boolean( ).valid( null ),
+  prefers_receive_mentions: Joi.boolean( ).valid( null ),
+  prefers_redundant_identification_notifications: Joi.boolean( ).valid( null ),
+  prefers_scientific_name_first: Joi.boolean( ).valid( null ),
+  preferred_sound_license: Joi.string( ).valid( null ),
+  prefers_taxon_change_email_notification: Joi.boolean( ).valid( null ),
+  prefers_taxon_or_place_observation_email_notification: Joi.boolean( ).valid( null ),
+  prefers_user_observation_email_notification: Joi.boolean( ).valid( null ),
+  privileges: Joi.array( ).items( Joi.string( ) ).valid( null ),
+  search_place_id: Joi.number( ).integer( ).valid( null ),
+  time_zone: Joi.string( ).valid( null ),
+  universal_search_rank: Joi.number( ).integer( )
+} );

--- a/openapi/schema/response/results_users_me.js
+++ b/openapi/schema/response/results_users_me.js
@@ -1,0 +1,9 @@
+const Joi = require( "joi" );
+const privateUser = require( "./private_user" );
+
+module.exports = Joi.object( ).keys( {
+  total_results: Joi.number( ).integer( ).required( ),
+  page: Joi.number( ).integer( ).required( ),
+  per_page: Joi.number( ).integer( ).required( ),
+  results: Joi.array( ).items( privateUser ).required( )
+} ).unknown( false );

--- a/openapi/schema/response/site.js
+++ b/openapi/schema/response/site.js
@@ -7,6 +7,6 @@ module.exports = Joi.object( ).keys( {
   locale: Joi.string( ).valid( null ),
   name: Joi.string( ),
   place_id: Joi.number( ).integer( ).valid( null ),
-  site_name_short: Joi.string( ),
+  site_name_short: Joi.string( ).valid( null ),
   url: Joi.string( )
 } ).unknown( false ).meta( { className: "Site" } );

--- a/openapi/schema/response/user.js
+++ b/openapi/schema/response/user.js
@@ -18,6 +18,22 @@ module.exports = Joi.object( ).keys( {
   name: Joi.string( ).valid( null ),
   observations_count: Joi.number( ).integer( ),
   orcid: Joi.string( ).valid( null ),
+  preferences: Joi.object( ).keys( {
+    prefers_community_taxa: Joi.boolean( )
+      .description( `
+        Whether the user allows the Community Taxon to be the taxon their observation is associated with
+      ` ),
+    prefers_observation_fields_by: Joi.string( ).valid(
+      "anyone",
+      "curators",
+      "observer"
+    ),
+    prefers_project_addition_by: Joi.string( ).valid(
+      "any",
+      "joined",
+      "none"
+    )
+  } ),
   roles: Joi.array( ).items( Joi.string( ) ),
   site: site.valid( null ),
   site_id: Joi.number( ).integer( ).valid( null ),

--- a/openapi/schema/response/user.js
+++ b/openapi/schema/response/user.js
@@ -12,6 +12,7 @@ module.exports = Joi.object( ).keys( {
   icon: Joi.string( ).valid( null ),
   identifications_count: Joi.number( ).integer( ),
   journal_posts_count: Joi.number( ).integer( ),
+  last_active: Joi.date( ).iso( ),
   login: Joi.string( ),
   monthly_supporter: Joi.boolean( ).valid( null ),
   name: Joi.string( ).valid( null ),

--- a/openapi/schema/response/user.js
+++ b/openapi/schema/response/user.js
@@ -7,76 +7,23 @@ module.exports = Joi.object( ).keys( {
     .required( ),
   // TODO make this required when we've added taxon.uuid to the ident index
   uuid: Joi.string( ).guid( { version: "uuidv4" } ),
-  activity_count: Joi.number( ).integer( ),
-  blocked_user_ids: Joi.array( ).items(
-    Joi.number( ).integer( )
-  ).valid( null ),
-  created_at: Joi.string( ),
+  created_at: Joi.string( ).isoDate( ),
   description: Joi.string( ).valid( null ),
-  email: Joi.string( ).valid( null ),
   icon: Joi.string( ).valid( null ),
-  icon_url: Joi.string( ).valid( null ),
   identifications_count: Joi.number( ).integer( ),
   journal_posts_count: Joi.number( ).integer( ),
-  locale: Joi.string( ).valid( null ),
   login: Joi.string( ),
-  login_autocomplete: Joi.string( ),
-  login_exact: Joi.string( ),
   monthly_supporter: Joi.boolean( ).valid( null ),
-  muted_user_ids: Joi.array( ).items(
-    Joi.number( ).integer( )
-  ).valid( null ),
   name: Joi.string( ).valid( null ),
-  name_autocomplete: Joi.string( ).valid( null ),
   observations_count: Joi.number( ).integer( ),
   orcid: Joi.string( ).valid( null ),
-  place_id: Joi.number( ).integer( ).valid( null ),
-  preferences: Joi.object( ).keys( {
-    prefers_community_taxa: Joi.boolean( ),
-    prefers_observation_fields_by: Joi.string( )
-      .description( "Allows this kind of user to add observation field values to their observations" ),
-    prefers_project_addition_by: Joi.string( )
-      .description( "Allows this kind of user to add their observations to projects" ),
-    prefers_common_names: Joi.boolean( )
-      .description( "Prefers to view common names" ),
-    prefers_scientific_name_first: Joi.boolean( )
-      .description( "Prefers to view scientific names before common names" )
-  } ).unknown( false ),
-  prefers_automatic_taxonomic_changes: Joi.boolean( ).valid( null ),
-  prefers_comment_email_notification: Joi.boolean( ).valid( null ),
-  prefers_common_names: Joi.boolean( ).valid( null ),
-  prefers_community_taxa: Joi.boolean( ).valid( null ),
-  prefers_identification_email_notification: Joi.boolean( ).valid( null ),
-  prefers_mention_email_notification: Joi.boolean( ).valid( null ),
-  prefers_message_email_notification: Joi.boolean( ).valid( null ),
-  prefers_monthly_supporter_badge: Joi.boolean( ).valid( null ),
-  prefers_no_email: Joi.boolean( ).valid( null ),
-  prefers_no_tracking: Joi.boolean( ).valid( null ),
-  preferred_observation_fields_by: Joi.string( ).valid( null ),
-  preferred_observation_license: Joi.string( ).valid( null ),
-  preferred_photo_license: Joi.string( ).valid( null ),
-  prefers_project_added_your_observation_email_notification: Joi.boolean( ).valid( null ),
-  preferred_project_addition_by: Joi.string( ).valid( null ),
-  prefers_project_curator_change_email_notification: Joi.boolean( ).valid( null ),
-  prefers_project_journal_post_email_notification: Joi.boolean( ).valid( null ),
-  prefers_receive_mentions: Joi.boolean( ).valid( null ),
-  prefers_redundant_identification_notifications: Joi.boolean( ).valid( null ),
-  prefers_scientific_name_first: Joi.boolean( ).valid( null ),
-  preferred_sound_license: Joi.string( ).valid( null ),
-  prefers_taxon_change_email_notification: Joi.boolean( ).valid( null ),
-  prefers_taxon_or_place_observation_email_notification: Joi.boolean( ).valid( null ),
-  prefers_user_observation_email_notification: Joi.boolean( ).valid( null ),
-  privileges: Joi.array( ).items( Joi.string( ) ).valid( null ),
   roles: Joi.array( ).items( Joi.string( ) ),
-  search_place_id: Joi.number( ).integer( ).valid( null ),
   site: site.valid( null ),
   site_id: Joi.number( ).integer( ).valid( null ),
   spam: Joi.boolean( ),
   species_count: Joi.number( ).integer( ),
   suspended: Joi.boolean( ),
-  time_zone: Joi.string( ).valid( null ),
-  universal_search_rank: Joi.number( ).integer( ),
-  updated_at: Joi.string( )
+  updated_at: Joi.string( ).isoDate( )
 } ).unknown( false )
   .meta( { className: "User" } )
   .valid( null );

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -1654,15 +1654,13 @@
         },
         {
           "id": 127,
-          "login": "user124",
-          "name": "User 124",
-          "description": "Observer that trusts user 123"
+          "login": "user127",
+          "name": "Observer that trusts user 123"
         },
         {
           "id": 128,
           "login": "user125",
-          "name": "User 125",
-          "description": "Observer that does NOT trust user 123"
+          "name": "Observer that does NOT trust user 123"
         },
         {
           "id": 2,
@@ -1679,14 +1677,12 @@
         {
           "id": 2020110501,
           "login": "user2020110501",
-          "name": "User 2020110501",
-          "description": "User that follows user 126 and trusts them"
+          "name": "User that follows user 126 and trusts them"
         },
         {
           "id": 2020111201,
           "login": "user2020111201",
-          "name": "User 2020111201",
-          "description": "User that follows user 126 and does NOT trusts them"
+          "name": "User that follows user 126 and does NOT trusts them"
         },
         {
           "id": 2021111401,
@@ -1697,14 +1693,12 @@
         {
           "id": 2021121601,
           "login": "user2021121601",
-          "name": "User 2021121601",
-          "description": "User that will be blocked"
+          "name": "User that will be blocked"
         },
         {
           "id": 2021121602,
           "login": "user2021121602",
-          "name": "User 2021121602",
-          "description": "User that blocks user2021121601"
+          "name": "User that blocks user2021121601"
         }
       ]
     },
@@ -2805,14 +2799,14 @@
       },
       {
         "id": 127,
-        "login": "user124",
-        "name": "User 124",
+        "login": "user127",
+        "name": "Observer that trusts user 123",
         "description": "Observer that trusts user 123"
       },
       {
         "id": 128,
         "login": "user125",
-        "name": "User 125",
+        "name": "Observer that does NOT trust user 123",
         "description": "Observer that does NOT trust user 123"
       },
       {
@@ -2830,13 +2824,13 @@
       {
         "id": 2020110501,
         "login": "user2020110501",
-        "name": "User 2020110501",
+        "name": "User that follows user 126 and trusts them",
         "description": "User that follows user 126 and trusts them"
       },
       {
         "id": 2020111201,
         "login": "user2020111201",
-        "name": "User 2020111201",
+        "name": "User that follows user 126 and does NOT trusts them",
         "description": "User that follows user 126 and does NOT trusts them"
       },
       {
@@ -2849,13 +2843,13 @@
       {
         "id": 2021121601,
         "login": "user2021121601",
-        "name": "User 2021121601",
+        "name": "User that will be blocked",
         "description": "User that will be blocked"
       },
       {
         "id": 2021121602,
         "login": "user2021121602",
-        "name": "User 2021121602",
+        "name": "User that blocks user2021121601",
         "description": "User that blocks user2021121601"
       }
     ],

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -2747,7 +2747,9 @@
         "id": 1,
         "login": "userlogin",
         "name": "username",
-        "site_id": 1
+        "site_id": 1,
+        "description": "a very original user",
+        "last_active": "2022-03-01"
       },
       {
         "id": 5,
@@ -2801,7 +2803,8 @@
         "id": 127,
         "login": "user127",
         "name": "Observer that trusts user 123",
-        "description": "Observer that trusts user 123"
+        "description": "Observer that trusts user 123",
+        "site_id": 1
       },
       {
         "id": 128,

--- a/test/integration/v2/users.js
+++ b/test/integration/v2/users.js
@@ -3,12 +3,27 @@ const fs = require( "fs" );
 const jwt = require( "jsonwebtoken" );
 const nock = require( "nock" );
 const request = require( "supertest" );
-const config = require( "../../../config.js" );
+const { expect } = require( "chai" );
+const config = require( "../../../config" );
 const app = require( "../../../app" );
 
 const fixtures = JSON.parse( fs.readFileSync( "schema/fixtures.js" ) );
 
 describe( "Users", ( ) => {
+  describe( "show", ( ) => {
+    it( "should include description when requested", done => {
+      const user = _.find(
+        fixtures.postgresql.users,
+        u => u.description && u.description.length > 0
+      );
+      request( app ).get( `/v2/users/${user.id}?fields=description` )
+        .expect( 200 )
+        .expect( res => {
+          expect( res.body.results[0].description ).to.eq( user.description );
+        } )
+        .expect( 200, done );
+    } );
+  } );
   describe( "update_session", ( ) => {
     it( "should fail without auth", done => {
       request( app ).put( "/v2/users/update_session" )
@@ -26,8 +41,11 @@ describe( "Users", ( ) => {
 
     it( "should return JSON with auth", done => {
       const currentUser = fixtures.elasticsearch.users.user[0];
-      const token = jwt.sign( { user_id: currentUser.id }, config.jwtSecret || "secret",
-        { algorithm: "HS512" } );
+      const token = jwt.sign(
+        { user_id: currentUser.id },
+        config.jwtSecret || "secret",
+        { algorithm: "HS512" }
+      );
       nock( "http://localhost:3000" )
         .put( "/users/update_session" )
         .reply( 204 );


### PR DESCRIPTION
The description attribute is not in the ES index, so our fixtures were actually incorrect. This fixes the fixtures and adds a new implementation of /v2/users/:id that loads data from the db and from ES every time, and can return all the in the documented response schema... which itself was wildly inaccurate as it included all of the private info returned by /v2/users/me, so I trimmed that down and made a separate schema for that.

Also added /v2/users to allow clients to show users that another user follows or users that follow that user.

Several other minor v2 fixes.

Closes #305