### PR TITLE
Fix inaccuracies in swagger_v1.yml.ejs

### DIFF
--- a/lib/views/swagger_v1.yml.ejs
+++ b/lib/views/swagger_v1.yml.ejs
@@ -3825,11 +3825,11 @@ definitions:
       identifications_count:
         type: integer
       identifications_most_agree:
-        type: integer
+        type: boolean
       identifications_most_disagree:
-        type: integer
+        type: boolean
       identifications_some_agree:
-        type: integer
+        type: boolean
       license_code:
         type: string
       location:
@@ -3867,7 +3867,7 @@ definitions:
         items:
           $ref: "#/definitions/Photo"
       place_guess:
-        type: integer
+        type: string
       place_ids:
         type: array
         items:
@@ -3885,7 +3885,7 @@ definitions:
         items:
           type: integer
       quality_grade:
-        type: integer
+        type: string
       reviewed_by:
         type: array
         items:
@@ -3936,11 +3936,11 @@ definitions:
           establishment_means:
             $ref: "#/definitions/EstablishmentMeans"
           introduced:
-            type: string
+            type: boolean
           native:
-           type: string
+           type: boolean
           threatened:
-            type: string
+            type: boolean
   Photo:
     type: object
     properties:
@@ -3961,7 +3961,8 @@ definitions:
         type: array
         description: an array of [long, lat]
         items:
-          type: string
+          type: number
+          format: double
   PolygonGeoJson:
     type: object
     properties:


### PR DESCRIPTION
I just generated [Rust API bindings for iNaturalist](https://github.com/frewsxcv/rust-inaturalist) and when I ran:

```rust
#[tokio::main]
async fn main() {
    let configuration = inaturalist::apis::configuration::Configuration {
        base_path: "https://api.inaturalist.org/v1".into(),
        ..Default::default()
    };

    let params = inaturalist::apis::observations_api::ObservationsGetParams {
        ..Default::default()
    };

    let observations = inaturalist::apis::observations_api::observations_get(
        &configuration,
        params
    ).await.unwrap();

    println!("{:?}", observations);
}
```

...I ran into deserialization errors because there are mismatched types between the Swagger file and what actually gets returned.