### PR TITLE
Add protocol to default Elasticsearch host name

### DIFF
--- a/config_example.js
+++ b/config_example.js
@@ -23,7 +23,7 @@ module.exports = {
   apiHostSSL: false,
   writeHostSSL: false,
   elasticsearch: {
-    host: INAT_ES_HOST ? `${INAT_ES_HOST}:9200` : "localhost:9200",
+    host: INAT_ES_HOST ? `http://${INAT_ES_HOST}:9200` : "http://localhost:9200",
     geoPointField: "location",
     searchIndex: `${environment}_observations`,
     placeIndex: `${environment}_places`


### PR DESCRIPTION
When setting up a local dev environment, the documentation instructs users to copy `config_example.js` to `config.js`. This config works _almost_ as-is. However the following error is thrown when the API tries to connect to Elasticsearch. 

```
Attaching to inaturalist_api
inaturalist_api    | /usr/src/app/node_modules/@elastic/transport/lib/connection/BaseConnection.js:116
inaturalist_api    |             throw new errors_1.ConfigurationError(`Invalid protocol: '${this.url.protocol}'`);
inaturalist_api    |             ^
inaturalist_api    | 
inaturalist_api    | ConfigurationError: Invalid protocol: 'es:'
inaturalist_api    |     at new BaseConnection (/usr/src/app/node_modules/@elastic/transport/lib/connection/BaseConnection.js:116:19)
inaturalist_api    |     at new Connection (/usr/src/app/node_modules/@elastic/transport/lib/connection/UndiciConnection.js:38:9)
inaturalist_api    |     at WeightedConnectionPool.createConnection (/usr/src/app/node_modules/@elastic/transport/lib/pool/BaseConnectionPool.js:141:28)
inaturalist_api    |     at WeightedConnectionPool.addConnection (/usr/src/app/node_modules/@elastic/transport/lib/pool/BaseConnectionPool.js:164:59)
inaturalist_api    |     at new Client (/usr/src/app/node_modules/@elastic/elasticsearch/lib/client.js:180:33)
inaturalist_api    |     at Object.esClient.connect (/usr/src/app/lib/es_client.js:28:25)
inaturalist_api    |     at Object.<anonymous> (/usr/src/app/lib/es_client.js:292:10)
inaturalist_api    |     at Module._compile (node:internal/modules/cjs/loader:1165:14)
inaturalist_api    |     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1219:10)
inaturalist_api    |     at Module.load (node:internal/modules/cjs/loader:1043:32)
```

This fix adds a protocol to the default ES host names for local development:

`es:9200` => `http://es:9200`
 `localhost:9200` => `http://localhost:9200`