### PR TITLE
endpoints and schemas can be marked as unpublished

### DIFF
--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -669,6 +669,74 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
     } );
   }
 
+  static prepareSwaggerUIApiDoc( req, originalSwaggerDoc ) {
+    // If the `unpublished` query parameter is not provided, filter out
+    // endpoints that work but that we are not committed to aintaining or
+    // supporting from visible documentation. Note that functionality like this
+    // does not seem to be a part of the OpenAPI spec, but is under
+    // consideration:
+    // https://github.com/OAI/OpenAPI-Specification/issues/433. Also note that I
+    // think this is a pretty crude solution to the problem of treating the API
+    // docs as a commitment to API consumers that we support all documented
+    // functionality for the life of this version. I think I'd prefer that we
+    // could somehow annotate some endpoints as private, annotate some as
+    // "unsupported," or provide some kind of param that shows these private and
+    // unsupported endpoints to people who are interested, like developers on
+    // staff. ~~kueda 20200813
+    let modifiedSwaggerDoc = _.cloneDeep( originalSwaggerDoc );
+    // remove x-express-* attributes which don't need to be in the official documentation
+    modifiedSwaggerDoc = _.pickBy( modifiedSwaggerDoc, ( value, key ) => !key.match( /^x-/ ) );
+    if ( !req.query.unpublished ) {
+      // exclude methods that are marked as unpublished
+      _.each( modifiedSwaggerDoc.paths, ( pathConfig, path ) => {
+        modifiedSwaggerDoc.paths[path] = _.omitBy( pathConfig, methodConfig => (
+          _.isPlainObject( methodConfig ) && methodConfig["x-unpublished"]
+        ) );
+      } );
+
+      // exclude paths that have no longer have methods
+      modifiedSwaggerDoc.paths = _.omitBy( modifiedSwaggerDoc.paths, pathConfig => (
+        // pathConfig contains `parameters` which is an array, and methods which are objects
+        _.isEmpty( _.pickBy( pathConfig, _.isPlainObject ) )
+      ) );
+
+      // exclude schemas that are marked as unpublished
+      modifiedSwaggerDoc.components.schemas = _.omitBy(
+        modifiedSwaggerDoc.components.schemas, ( schema, schemaName ) => {
+          let joiSchema;
+          const schemaPathName = _.snakeCase( schemaName );
+          // The JOI schema needs to be loaded from the schema file as the
+          // initialized OpenAPI doc will have turned component schemas into
+          // simple JSON objects, losing some JOI properties like meta tags
+          const requestSchemaPath = `openapi/schema/request/${schemaPathName}.js`;
+          const responeSchemaPath = `openapi/schema/response/${schemaPathName}.js`;
+          // Schemas can come from the request or reqponse directories
+          _.each( [requestSchemaPath, responeSchemaPath], schemaPath => {
+            if ( !joiSchema && fs.existsSync( schemaPath ) ) {
+              // eslint-disable-next-line
+              joiSchema = require( `../${schemaPath}` );
+            }
+          } );
+          if ( joiSchema ) {
+            const schemaMetas = _.get( joiSchema, "$_terms.metas" );
+            return _.some( schemaMetas, meta => meta.unpublished );
+          }
+          return false;
+        }
+      );
+
+      // exclude tags that are not referenced by any remaining paths
+      modifiedSwaggerDoc.tags = _.filter( modifiedSwaggerDoc.tags, tag => (
+        _.some( modifiedSwaggerDoc.paths, pathConfig => (
+          _.some( pathConfig, methodConfig => (
+            _.isPlainObject( methodConfig ) && _.includes( methodConfig.tags, tag.name )
+          ) )
+        ) )
+      ) );
+    }
+    return modifiedSwaggerDoc;
+  }
+
   static async initializeOpenapi( inaturalistAPIExpressApp ) {
     // method override middleware must be defined before initializing openapi
     InaturalistAPIV2.applyMethodOverrideMiddleware( inaturalistAPIExpressApp );
@@ -691,8 +759,7 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
         sendWrapper: InaturalistAPIV2.sendWrapper
       },
       securityFilter: ( req, res ) => {
-        // remove x-express-* attributes which don't need to be in the official documentation
-        res.status( 200 ).json( _.pickBy( req.apiDoc, ( value, key ) => !key.match( /^x-/ ) ) );
+        res.status( 200 ).json( InaturalistAPIV2.prepareSwaggerUIApiDoc( req, req.apiDoc ) );
       },
       paths: "./openapi/paths/v2",
       promiseMode: true,
@@ -750,53 +817,16 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
       customSiteTitle: "iNaturalist API",
       customfavIcon: "/favicon.ico"
     };
-    // Filter out endpoints from that work but that we are not committed to
-    // maintaining or supporting from visible documentation. Note that
-    // functionality like this does not seem to be a part of the OpenAPI spec,
-    // but is under consideration:
-    // https://github.com/OAI/OpenAPI-Specification/issues/433. Also note that I
-    // think this is a pretty crude solution to the problem of treating the API
-    // docs as a commitment to API consumers that we support all documented
-    // functionality for the life of this version. I think I'd prefer that we
-    // could somehow annotate some endpoints as private, annotate some as
-    // "unsupported," or provide some kind of param that shows these private and
-    // unsupported endpoints to people who are interested, like developers on
-    // staff. ~~kueda 20200813
-    const swaggerApiDoc = {
-      ...initializedOpenapi.apiDoc,
-      paths: _.omitBy(
-        initializedOpenapi.apiDoc.paths,
-        ( pathConfig, path ) => (
-          path.match( /computervision/ ) || [
-            "/log"
-          ].indexOf( path ) >= 0
-        )
-      ),
-      tags: _.sortBy(
-        _.omitBy(
-          initializedOpenapi.apiDoc.tags,
-          tag => (
-            tag.name.match( /Computer Vision/ ) || [
-              "Log"
-            ].indexOf( tag.name ) >= 0
-          )
-        ),
-        tag => tag.name
-      ),
-      components: {
-        ...initializedOpenapi.apiDoc.components,
-        schemas: _.omitBy(
-          initializedOpenapi.apiDoc.components.schemas,
-          ( schema, schemaName ) => (
-            schemaName.match( /vision/i ) || [
-              "LogCreate"
-            ].indexOf( schemaName ) >= 0
-          )
-        )
-      }
-    };
-    const swaggerUIMiddleware = swaggerUi.setup( swaggerApiDoc, swaggerOptions );
-    inaturalistAPIExpressApp.use( "/v2/docs", swaggerUi.serve, swaggerUIMiddleware );
+    const swaggerUIMiddleware = swaggerUi.setup( initializedOpenapi.apiDoc, swaggerOptions );
+    inaturalistAPIExpressApp.use(
+      "/v2/docs",
+      ( req, res, next ) => {
+        req.swaggerDoc = InaturalistAPIV2.prepareSwaggerUIApiDoc( req, initializedOpenapi.apiDoc );
+        next( );
+      },
+      swaggerUi.serve,
+      swaggerUIMiddleware
+    );
   }
 };
 

--- a/openapi/paths/v2/computervision/score_image.js
+++ b/openapi/paths/v2/computervision/score_image.js
@@ -12,6 +12,7 @@ module.exports = sendWrapper => {
     security: [{
       appOrUserJwtRequired: []
     }],
+    "x-unpublished": true,
     requestBody: {
       content: {
         "multipart/form-data": {

--- a/openapi/paths/v2/computervision/score_observation/{uuid}.js
+++ b/openapi/paths/v2/computervision/score_observation/{uuid}.js
@@ -14,6 +14,7 @@ module.exports = sendWrapper => {
     security: [{
       appOrUserJwtRequired: []
     }],
+    "x-unpublished": true,
     parameters: [
       transform(
         Joi.string( ).guid( )

--- a/openapi/paths/v2/log.js
+++ b/openapi/paths/v2/log.js
@@ -17,6 +17,7 @@ module.exports = sendWrapper => {
     security: [{
       appOrUserJwtRequired: []
     }],
+    "x-unpublished": true,
     requestBody: {
       content: {
         "application/json": {

--- a/openapi/schema/request/computervision_score_image.js
+++ b/openapi/schema/request/computervision_score_image.js
@@ -8,4 +8,5 @@ module.exports = Joi.object( ).keys( {
   //   observation_id: Joi.number( ).integer( )
   // } ).unknown( false ),
   image: Joi.binary( ).required( )
-} ).unknown( true );
+} ).unknown( true )
+  .meta( { unpublished: true } );

--- a/openapi/schema/request/log_create.js
+++ b/openapi/schema/request/log_create.js
@@ -13,4 +13,4 @@ module.exports = Joi.object( ).keys( {
   backtrace: Joi.string( )
 } ).description(
   "Log an event that occurred in a client application"
-);
+).meta( { unpublished: true } );

--- a/openapi/schema/response/results_computervision.js
+++ b/openapi/schema/response/results_computervision.js
@@ -38,4 +38,5 @@ module.exports = Joi.object( ).keys( {
     before one with a vision_score of 1. None of the scores are probabilities of
     accuracy or measures of confidence.
   `.replace( /\s+/m, " " ) )
-} ).unknown( false );
+} ).unknown( false )
+  .meta( { unpublished: true } );


### PR DESCRIPTION
Implements an `x-unpublished` attribute for methods and `.meta( { unpublished: true } )` for schemas which prevents each from displaying in the documentation by default, as mentioned in https://github.com/inaturalist/iNaturalistAPI/pull/360. These replace the hard-coded exclusions we were previously using, and also removes them from the JSON documentation. A `?unpublished=true` parameter can be included in the URL to display all unpublished methods and schemas.

I'm not committed to this approach, rather offering it at as more general way of having unpublished endpoints and schemas by giving them attributes, rather than updating a central exclusion method. We can modify what displays in the SwaggerUI documentation as well as the JSON documentation based on the incoming request, so there's a variety of ways we could conditionally display unpublished documentation.