### PR TITLE
Update `swagger_v1.yml.ejs` to reflect `ancestor_ids` being returned in `ShowTaxon`

### DIFF
--- a/lib/views/swagger_v1.yml.ejs
+++ b/lib/views/swagger_v1.yml.ejs
@@ -4114,6 +4114,10 @@ definitions:
       - $ref: "#/definitions/CoreTaxon"
       - type: object
         properties:
+          ancestor_ids:
+            type: array
+            items:
+              type: integer
           colors:
             type: array
             items:


### PR DESCRIPTION
![Screenshot 2023-02-20 at 10 27 39 PM](https://user-images.githubusercontent.com/416575/220240116-124d3e72-768f-49b1-8f4e-5e0dab619e10.png)
