### PR TITLE
Update `rank_level` to allow floating point numbers

### DIFF
--- a/lib/views/swagger_v1.yml.ejs
+++ b/lib/views/swagger_v1.yml.ejs
@@ -2793,7 +2793,7 @@ parameters:
   # Taxa
   rank_level:
     name: rank_level
-    type: integer
+    type: number
     in: query
     description: |
       Taxon must have this rank level. Some example values are 70 (kingdom),
@@ -3694,7 +3694,7 @@ definitions:
       rank:
         type: string
       rank_level:
-        type: integer
+        type: number
   DateDetails:
     type: object
     properties:

--- a/openapi/schema/request/taxa_search.js
+++ b/openapi/schema/request/taxa_search.js
@@ -31,7 +31,7 @@ module.exports = Joi.object( ).keys( {
     "variety",
     "form"
   ) ),
-  rank_level: Joi.number( ).integer( ),
+  rank_level: Joi.number( ),
   id_above: Joi.number( ).integer( ),
   id_below: Joi.number( ).integer( ),
   per_page: Joi.number( ).integer( ),


### PR DESCRIPTION
https://github.com/inaturalist/inaturalist/blob/8c53f2f4143e9c45b4e16a864ae069ec65beff7d/app/models/taxon.rb#L180-L184

Fixes: https://github.com/inaturalist/iNaturalistAPI/issues/373