### PR TITLE
Add no_total_hits param

### DIFF
--- a/lib/controllers/v1/identifications_controller.js
+++ b/lib/controllers/v1/identifications_controller.js
@@ -83,7 +83,7 @@ const IdentificationsController = class IdentificationsController {
     const response = await IdentificationsController.elasticResults( req );
     const ids = _.map( response.hits.hits, h => new Identification( h._source ) );
     return {
-      total_results: response.hits.total.value,
+      total_results: response.hits.total ? response.hits.total.value : ids.length,
       page: Number( req.elastic_query.page ),
       per_page: Number( req.elastic_query.per_page ),
       results: ids
@@ -93,7 +93,9 @@ const IdentificationsController = class IdentificationsController {
   static async elasticResults( req ) {
     const query = IdentificationsController.reqToElasticQuery( req );
     return ESModel.elasticResults( req, query, "identifications", {
-      track_total_hits: !req.query.skip_total_hits
+      track_total_hits: !req.query.skip_total_hits && !req.query.no_total_hits,
+      skip_total_hits: req.query.skip_total_hits,
+      no_total_hits: req.query.no_total_hits
     } );
   }
 
@@ -396,7 +398,7 @@ const IdentificationsController = class IdentificationsController {
     const taxonOpts = {
       modifier: prepareTaxon,
       filters: [{ term: { is_active: true } }],
-      source: { excludes: ["photos", "taxon_photos"] }
+      source: { excludes: ["photos", "taxon_photos", "place_ids"] }
     };
     await ESModel.fetchBelongsTo( pageResults, Taxon, taxonOpts );
     await ESModel.fetchBelongsTo( idents, Observation, obsOpts );

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -214,7 +214,9 @@ ObservationsController.elasticResults = async function observationElasticResults
   req.elastic_query = query;
   const opts = {
     excludes: ["taxon.names", "taxon.photos", "taxon.taxon_photos", "taxon.names_*"],
-    track_total_hits: !req.query.skip_total_hits
+    track_total_hits: !req.query.skip_total_hits && !req.query.no_total_hits,
+    skip_total_hits: req.query.skip_total_hits,
+    no_total_hits: req.query.no_total_hits
   };
   const returnOnlyID = req.query.only_id && req.query.only_id !== "false";
   if ( returnOnlyID ) {
@@ -313,7 +315,7 @@ ObservationsController.histogram = async req => {
   }
   // return nothing but aggregations
   countQuery.per_page = 0;
-  countQuery.skip_total_hits = true;
+  countQuery.no_total_hits = true;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const resultOptions = { };
@@ -336,7 +338,9 @@ ObservationsController.histogram = async req => {
 
 ObservationsController.prepareElasticDataForReponse = ( data, req ) => {
   const obs = _.map( data.hits.hits, "_source" );
-  const response = { total_results: data.hits.total.value };
+  const response = {
+    total_results: data.hits.total ? data.hits.total.value : obs.length
+  };
   if (
     data.aggregations
     && data.aggregations.bbox
@@ -858,7 +862,7 @@ ObservationsController.taxonomy = async req => {
 
   const countQuery = _.assignIn( { }, req.query, {
     per_page: 0,
-    skip_total_hits: true,
+    no_total_hits: true,
     order_by: "none",
     aggs: {
       min_species_taxon_ids: {
@@ -934,7 +938,7 @@ ObservationsController.iconicTaxaCounts = async req => {
   };
   const taxonOpts = {
     modifier: prepareTaxon,
-    source: { excludes: ["photos", "taxon_photos"] }
+    source: { excludes: ["photos", "taxon_photos", "place_ids"] }
   };
   await ESModel.fetchBelongsTo( buckets, Taxon, taxonOpts );
   return {
@@ -990,7 +994,7 @@ ObservationsController.iconicTaxaSpeciesCounts = async req => {
   };
   const taxonOpts = {
     modifier: prepareTaxon,
-    source: { excludes: ["photos", "taxon_photos"] }
+    source: { excludes: ["photos", "taxon_photos", "place_ids"] }
   };
   await ESModel.fetchBelongsTo( iconicTaxonLeafCounts, Taxon, taxonOpts );
   return {
@@ -1076,7 +1080,7 @@ ObservationsController.umbrellaProjectStats = async req => {
     }
   };
   req.query.order_by = "none";
-  const countQuery = _.assignIn( { }, req.query, { per_page: 0, aggs, skip_total_hits: true } );
+  const countQuery = _.assignIn( { }, req.query, { per_page: 0, aggs, no_total_hits: true } );
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const obsAggs = data.aggregations;
@@ -1146,7 +1150,7 @@ ObservationsController.observers = async req => {
   const observers = await ObservationsController.observationsObserverCounts( _.cloneDeep( req ) );
   const spQuery = _.assignIn( { }, req.query );
   spQuery.user_id = _.keys( observers.counts );
-  spQuery.skip_total_hits = true;
+  spQuery.no_total_hits = true;
   if ( _.isEmpty( spQuery.user_id ) ) {
     return ObservationsController.observationsObserversResponse( req, observers, { counts: { } } );
   }
@@ -1208,7 +1212,7 @@ ObservationsController.observationsObserverCounts = async req => {
     }
   }
   countQuery.per_page = 0;
-  countQuery.skip_total_hits = true;
+  countQuery.no_total_hits = true;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   let counts = { };
@@ -1265,7 +1269,7 @@ ObservationsController.observationsSpeciesObserverCounts = async req => {
     }
   }
   countQuery.per_page = 0;
-  countQuery.skip_total_hits = true;
+  countQuery.no_total_hits = true;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   let userIndexedCounts = { };
@@ -1442,7 +1446,7 @@ ObservationsController.popularFieldValues = async req => {
     };
   }
   countQuery.per_page = 0;
-  countQuery.skip_total_hits = true;
+  countQuery.no_total_hits = true;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const resultOptions = { backfill: { min: 1, max: interval === "month" ? 12 : 52 } };
@@ -1629,7 +1633,7 @@ ObservationsController.similarSpecies = async req => {
     categories: { terms: { field: "ident_taxon_ids", size: 200, exclude: taxon.ancestor_ids } }
   };
   countQuery.per_page = 0;
-  countQuery.skip_total_hits = true;
+  countQuery.no_total_hits = true;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const buckets = _.map( data.aggregations.categories.buckets, b => ( {

--- a/lib/models/es_model.js
+++ b/lib/models/es_model.js
@@ -169,7 +169,7 @@ const ESModel = class ESModel {
   static async ancestriesSpeciesCountsFetch( req, field, searchMethod ) {
     const countQuery = _.assignIn( { }, req.query, {
       per_page: 0,
-      skip_total_hits: true,
+      no_total_hits: true,
       aggs: {
         ancestries: { terms: { field, size: 500000 } }
       }
@@ -216,6 +216,8 @@ const ESModel = class ESModel {
     }
     if ( options.track_total_hits ) {
       searchHash.track_total_hits = true;
+    } else if ( options.no_total_hits ) {
+      searchHash.track_total_hits = false;
     }
     return esClient.search( index, {
       body: searchHash
@@ -243,7 +245,7 @@ const ESModel = class ESModel {
   static async userAggregationQuery( req, countQuery, searchMethod, options ) {
     options = options || { };
     countQuery.per_page = 0;
-    countQuery.skip_total_hits = true;
+    countQuery.no_total_hits = true;
     const countReq = _.assignIn( { }, req, { query: countQuery } );
     const data = await searchMethod( countReq );
     return ESModel.userAggregationResponse( req, data, options );

--- a/lib/models/identification.js
+++ b/lib/models/identification.js
@@ -25,7 +25,7 @@ const Identification = class Identification extends Model {
     };
     const taxonOpts = {
       modifier: prepareTaxon,
-      source: { excludes: ["photos", "taxon_photos"] }
+      source: { excludes: ["photos", "taxon_photos", "place_ids"] }
     };
     await DBModel.fetchBelongsTo( arr, Identification );
     const identification = _.map( arr, "identification" );

--- a/lib/models/observation.js
+++ b/lib/models/observation.js
@@ -222,7 +222,7 @@ const Observation = class Observation extends Model {
         taxon_id: "taxon",
         previous_observation_taxon_id: "previous_observation_taxon"
       },
-      source: { excludes: ["photos", "taxon_photos"] }
+      source: { excludes: ["photos", "taxon_photos", "place_ids"] }
     };
     await ObservationPreload.identifications( obs );
     await ObservationPreload.projectObservations( obs );


### PR DESCRIPTION
using `?no_total_hits=true` results in an [Elasticsearch query setting](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-your-data.html#track-total-hits) `track_total_hits:false`. This can result in faster queries than the default behavior of not specify any value for `track_total_hits` which is set by default to 10,000. The value of total_results in the response is simply set to the number of results in the response of the given request for now, but in the future we could exclude `total_entries` entirely in case that behavior is confusing