### PR TITLE
Indicate the the 'observation search' request takes pagination parameters.

### DIFF
--- a/lib/views/_observation_search_params_v1.yml.ejs
+++ b/lib/views/_observation_search_params_v1.yml.ejs
@@ -94,8 +94,6 @@
         - $ref: "#/parameters/locale"
         - $ref: "#/parameters/preferred_place_id"
         - $ref: "#/parameters/ttl"
-<% } -%>
-<% if ( type === "index" ) { -%>
         - $ref: "#/parameters/page"
         - $ref: "#/parameters/per_page"
         - $ref: "#/parameters/order"


### PR DESCRIPTION
Assuming I'm reading the source correctly, this request does honor these parameters: 

https://github.com/inaturalist/iNaturalistAPI/blob/30987c8fe5b00b8a56ad7eb96c44402530efa5d6/openapi/schema/request/observations_search.js#L282-L296