### PR TITLE
372 search by orcid

### DIFF
--- a/lib/controllers/v1/search_controller.js
+++ b/lib/controllers/v1/search_controller.js
@@ -64,7 +64,7 @@ SearchController.search = async req => {
         filter: {
           multi_match: {
             query: q,
-            fields: ["*_autocomplete", "name",  "orcid"],
+            fields: ["*_autocomplete", "name"],
             fuzziness: "AUTO",
             prefix_length: 5,
             max_expansions: 2,
@@ -119,10 +119,23 @@ SearchController.search = async req => {
     {
       constant_score: {
         filter: {
-          match: {
-            login_exact: {
-              query: q
-            }
+          bool: {
+            should: [
+              {
+                match: {
+                  login_exact: {
+                    query: q
+                  }
+                }
+              },
+              {
+                match: {
+                  orcid: {
+                    query: q
+                  }
+                }
+              }
+            ]
           }
         },
         boost: 3

--- a/lib/controllers/v1/search_controller.js
+++ b/lib/controllers/v1/search_controller.js
@@ -64,7 +64,7 @@ SearchController.search = async req => {
         filter: {
           multi_match: {
             query: q,
-            fields: ["*_autocomplete", "name"],
+            fields: ["*_autocomplete", "name",  "orcid"],
             fuzziness: "AUTO",
             prefix_length: 5,
             max_expansions: 2,

--- a/lib/controllers/v2/users_controller.js
+++ b/lib/controllers/v2/users_controller.js
@@ -70,6 +70,10 @@ const index = async req => {
     );
     filters.push( esClient.termFilter( "id", _.map( followees, f => f.friend_id ) ) );
   }
+  if ( req.query.orcid ) {
+    filters.push( esClient.termFilter( "orcid", req.query.orcid ));
+  }
+
   const response = await esClient.search( "users", {
     body: {
       query: {

--- a/openapi/schema/request/users_index.js
+++ b/openapi/schema/request/users_index.js
@@ -19,5 +19,9 @@ module.exports = Joi.object( ).keys( {
       Joi.string( ).guid( )
     )
     .example( "1234" )
-    .description( "Show users followed by this user, specified by sequential ID, username, or UUID" )
+    .description( "Show users followed by this user, specified by sequential ID, username, or UUID" ),
+  orcid: Joi
+    .string()
+    .example("0000-0001-0002-0004")
+    .description("Show users with the specified orcid")
 } );

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -1644,7 +1644,8 @@
         {
           "id": 123,
           "login": "a-user",
-          "name": "A User"
+          "name": "A User",
+          "orcid": "0000-0001-0002-0004"
         },
         {
           "id": 124,

--- a/test/integration/v1/search.js
+++ b/test/integration/v1/search.js
@@ -34,6 +34,12 @@ describe( "Search", ( ) => {
       } ).expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );
+    it( "returns user by orcid", function ( done ) {
+      request( this.app ).get( "/v1/search?q=0000-0001-0002-0004" ).expect( res => {
+        expect( _.filter( res.body.results, r => r.record.login === 'a-user').length ).to.be.above( 0 );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
     it( "returns substring matches", function ( done ) {
       request( this.app ).get( "/v1/search?q=test+user" ).expect( res => {
         expect( _.filter( res.body.results, r => r.record.login === "search_test_user" ).length ).to.be.above( 0 );

--- a/test/integration/v2/search.js
+++ b/test/integration/v2/search.js
@@ -35,8 +35,8 @@ describe( "Search", ( ) => {
         .expect( 200, done );
     } );
     it( "returns user by orcid", function ( done ) {
-      request( this.app ).get( "/v1/search?q=0000-0001-0002-0004" ).expect( res => {
-        expect( _.filter( res.body.results, r => r.record.login === 'a-user').length ).to.be.above( 0 );
+      request( this.app ).get( "/v2/search?q=0000-0001-0002-0004&fields=all" ).expect( res => {
+        expect( _.filter( res.body.results, r => r?.user?.login === 'a-user').length ).to.be.above( 0 );
       } ).expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );

--- a/test/integration/v2/search.js
+++ b/test/integration/v2/search.js
@@ -34,6 +34,12 @@ describe( "Search", ( ) => {
       } ).expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );
+    it( "returns user by orcid", function ( done ) {
+      request( this.app ).get( "/v1/search?q=0000-0001-0002-0004" ).expect( res => {
+        expect( _.filter( res.body.results, r => r.record.login === 'a-user').length ).to.be.above( 0 );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
     it( "returns substring matches", function ( done ) {
       request( this.app ).get( "/v2/search?q=test+user&fields=all" ).expect( res => {
         expect( _.filter( res.body.results, r => r?.user?.login === "search_test_user" ).length ).to.be.above( 0 );

--- a/test/integration/v2/users.js
+++ b/test/integration/v2/users.js
@@ -153,6 +153,15 @@ describe( "Users", ( ) => {
         } )
         .expect( 200, done );
     } );
+    it( "should return by searched Orcid", function ( done ) {
+      request( this.app ).get( "/v2/users?orcid=0000-0001-0002-0004&fields=login" )
+        .expect( 200 )
+        .expect( res => {
+          expect( res.body.results ).not.to.be.empty;
+          expect( res.body.results[0].login ).to.eq("a-user");
+        } )
+        .expect( 200, done );
+    } );
   } );
 
   describe( "update", ( ) => {
@@ -207,4 +216,5 @@ describe( "Users", ( ) => {
         .expect( 200, done );
     } );
   } );
+
 } );


### PR DESCRIPTION
[ Allow users to search by ORCID #372 ](https://github.com/inaturalist/iNaturalistAPI/issues/372)
I tested this by directly inserting a row into provider_authorizations and was able to get a successful return when I provided the entire orcid (provider_uid) to the search endpoint
Added integrations tests as well