### PR TITLE
Configurable maintenance mode

### DIFF
--- a/config_example.js
+++ b/config_example.js
@@ -60,4 +60,6 @@ module.exports = {
     host: INAT_REDIS_HOST || "127.0.0.1",
     port: 6379
   }
+  // Simulate maintance by returning 503 for all requests
+  // maintenanceUntil: "Sat, 23 Sep 2023 7:00:00 GMT"
 };

--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -52,6 +52,12 @@ InaturalistAPI.prepareApp = ( ) => {
   server.use( InaturalistAPI.lookupInstancesMiddleware );
   server.use( InaturalistAPI.validateSession );
   server.use( InaturalistAPI.validateApplication );
+  if ( config.maintenanceUntil ) {
+    server.all( "*", ( _req, res ) => {
+      res.set( "Retry-After", config.maintenanceUntil );
+      res.sendStatus( 503 );
+    } );
+  }
   return server;
 };
 


### PR DESCRIPTION
This is mostly for testing client apps, but it adds a config property that will cause the server to reply with 503 Service Unavailable for all requests.