### PR TITLE
fix: 🐛 clean catch elastic search errors [v2]

### DIFF
--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -85,14 +85,15 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
       return;
     }
 
-    // Return clean elastic search errors
-    if( err.meta ){
-      status = err.meta.statusCode || 500;
-      if( err.body ){
-        const body = err.body.error || {};
-        if( body.type && body.root_cause ){
-          err.custom_message = { type: body.type, root_cause: body.root_cause };
-        }
+    // Return clean elastic search errors, with special cases for some common ones
+    if ( err.meta ) {
+      status = 500;
+      const reason = _.get( err, "meta.body.error.root_cause[0].reason", undefined );
+      if ( /^Result window is too large/.test( reason ) ) {
+        const size = reason.match( /\[(\d+)\]/ )[1];
+        err.custom_message = `Result window is too large, page + size must be less than or equal to [${size}]. Please narrow your search, or use a sliding window approach with id_above or id_below params.`;
+      } else {
+        err.custom_message = "Elasticsearch error, if this persists please contact the iNaturalist development team.";
       }
     }
 

--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -83,6 +83,18 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
       } ).catch( ( ) => InaturalistAPIV2.renderDefaultError( res, err, status ) );
       return;
     }
+
+    // Return clean elastic search errors
+    if( err.meta ){
+      status = err.meta.statusCode || 500;
+      if( err.body ){
+        const body = err.body.error || {};
+        if( body.type && body.root_cause ){
+          err.custom_message = { type: body.type, root_cause: body.root_cause };
+        }
+      }
+    }
+
     InaturalistAPIV2.renderDefaultError( res, err, status );
   }
 

--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -87,7 +87,6 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
 
     // Return clean elastic search errors, with special cases for some common ones
     if ( err.meta ) {
-      status = 500;
       const reason = _.get( err, "meta.body.error.root_cause[0].reason", undefined );
       if ( /^Result window is too large/.test( reason ) ) {
         const size = reason.match( /\[(\d+)\]/ )[1];

--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -91,7 +91,7 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
       const reason = _.get( err, "meta.body.error.root_cause[0].reason", undefined );
       if ( /^Result window is too large/.test( reason ) ) {
         const size = reason.match( /\[(\d+)\]/ )[1];
-        err.custom_message = `Result window is too large, page + size must be less than or equal to [${size}]. Please narrow your search, or use a sliding window approach with id_above or id_below params.`;
+        err.custom_message = `Result window is too large, page x size must be less than or equal to [${size}]. Please narrow your search, or use a sliding window approach with id_above or id_below params.`;
       } else {
         err.custom_message = "Elasticsearch error, if this persists please contact the iNaturalist development team.";
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,10 +27,19 @@ const util = class util {
     } else if ( config.debug && err.error ) {
       message = err.error;
     }
-    if ( err.message && err.message.match( "Result window is too large" ) ) {
-      status = 403;
-      message = "Result window is too large, page * per_page must be less than or equal to 10000";
+
+    // Return clean elastic search errors, with special cases for some common ones
+    if ( err.meta ) {
+      const reason = _.get( err, "meta.body.error.root_cause[0].reason", undefined );
+      if ( /^Result window is too large/.test( reason ) ) {
+        status = 403;
+        const size = reason.match( /\[(\d+)\]/ )[1];
+        message = `Result window is too large, page x size must be less than or equal to [${size}]. Please narrow your search, or use a sliding window approach with id_above or id_below params.`;
+      } else {
+        message = "Elasticsearch error, if this persists please contact the iNaturalist development team.";
+      }
     }
+
     Logstasher.writeErrorLog( err );
     res.status( status );
 

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -789,6 +789,19 @@ describe( "Observations", ( ) => {
           expect( ids ).to.contain( obsWithNoPositionalAccuracy );
         } ).expect( 200, done );
     } );
+
+    it( "should error with internal server error as result window is too large for elastic search", function ( done ) {
+      request( this.app )
+        .get( "/v1/observations?page=700" )
+        .expect( "Content-Type", /json/ )
+        .expect( res => {
+          expect( res.body.error ).to.exist;
+          // We return a special case error message, detect if it contains part of it
+          expect( res.body.error ).to.contains( "page x size" );
+        } )
+        .expect( 403, done );
+    } );
+
     describe( "viewed by project curator", ( ) => {
       const curatorProjectUser = _.find( fixtures.postgresql.project_users, pu => pu.id === 6 );
       const token = jwt.sign( { user_id: curatorProjectUser.user_id },

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -367,7 +367,7 @@ describe( "Observations", ( ) => {
         .expect( res => {
           expect( res.body.errors ).to.exist;
           // We return a special case error message, detect if it contains part of it
-          expect( res.body.errors[0].message ).to.contains( "page + size" );
+          expect( res.body.errors[0].message ).to.contains( "page x size" );
         } )
         .expect( 500, done );
     } );

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -359,6 +359,13 @@ describe( "Observations", ( ) => {
         .expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );
+
+    it( "should error with bad request as result window is too large for elastic search", function ( done ) {
+      request( this.app )
+        .get( "/v2/observations?page=350" )
+        .expect( "Content-Type", /json/ )
+        .expect( 400, done );
+    } );
   } );
 
   describe( "create", ( ) => {

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -360,11 +360,16 @@ describe( "Observations", ( ) => {
         .expect( 200, done );
     } );
 
-    it( "should error with bad request as result window is too large for elastic search", function ( done ) {
+    it( "should error with internal server error as result window is too large for elastic search", function ( done ) {
       request( this.app )
-        .get( "/v2/observations?page=350" )
+        .get( "/v2/observations?page=700" )
         .expect( "Content-Type", /json/ )
-        .expect( 400, done );
+        .expect( res => {
+          expect( res.body.errors ).to.exist;
+          // We return a special case error message, detect if it contains part of it
+          expect( res.body.errors[0].message ).to.contains( "page + size" );
+        } )
+        .expect( 500, done );
     } );
   } );
 


### PR DESCRIPTION
Errors from elastic search have a different structure. I try to catch them in the error middleware to give a cleaner response.

Additionally, added a very simple test case, although the test will fail if the elastic search window size is manually increases or a future version of elastic search will increase the default value. Therefore it is not a stable test.

This is my "solution" for the issue I posted a while ago:
https://github.com/inaturalist/iNaturalistAPI/issues/379

Alternatively, we could write for this special case an even nicer error message, eg. "please use sliding window (lastId) if you want to search deeper". But I would say no, as I'm no big fan special hardcoded exceptions.

✅ tests on `--fgrep search` all good

Cheers
Hannes


