### PR TITLE
refactor: :recycle: ignore .vscode and operation system temps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
-
-### Custom ###
+**/.DS_Store
+.coveralls.yml
+.ruby-gemset
+coverage
+node_modules
 config.js
 docker-compose.override.yml
 newrelic.js
+*.log
 restart.sh
 config/deploy
 config/deploy.rb
@@ -16,102 +20,8 @@ lib/vision/**
 !lib/vision/photos_csv_transformer.js
 !lib/vision/run_stats.js
 cache/**
+log/**
 openapi/uploads/**
 lib/tasks/**.csv
 env.list
 build
-.vscode
-
-### Ruby ###
-.ruby-gemset
-
-### NPM & NODE ###
-.npm
-node_modules
-*.log
-npm-debug.log*
-.eslintcache
-
-### Testing, Istanbul ###
-coverage
-*.lcov
-.coveralls.yml
-
-# Created by https://www.toptal.com/developers/gitignore/api/linux,windows,macOS
-# Edit at https://www.toptal.com/developers/gitignore?templates=linux,windows,macOS
-
-### Linux ###
-*~
-
-# temporary files which can be created if a process still has a handle open of a deleted file
-.fuse_hidden*
-
-# KDE directory preferences
-.directory
-
-# Linux trash folder which might appear on any partition or disk
-.Trash-*
-
-# .nfs files are created when an open file is removed but is still being accessed
-.nfs*
-
-### macOS ###
-# General
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-### macOS Patch ###
-# iCloud generated files
-*.icloud
-
-### Windows ###
-# Windows thumbnail cache files
-Thumbs.db
-Thumbs.db:encryptable
-ehthumbs.db
-ehthumbs_vista.db
-
-# Dump file
-*.stackdump
-
-# Folder config file
-[Dd]esktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msix
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-
-# End of https://www.toptal.com/developers/gitignore/api/linux,windows,macOS

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/.DS_Store
+.DS_Store
 .coveralls.yml
 .ruby-gemset
 coverage
@@ -25,3 +25,4 @@ openapi/uploads/**
 lib/tasks/**.csv
 env.list
 build
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
-**/.DS_Store
-.coveralls.yml
-.ruby-gemset
-coverage
-node_modules
+
+### Custom ###
 config.js
 docker-compose.override.yml
 newrelic.js
-*.log
 restart.sh
 config/deploy
 config/deploy.rb
@@ -20,8 +16,102 @@ lib/vision/**
 !lib/vision/photos_csv_transformer.js
 !lib/vision/run_stats.js
 cache/**
-log/**
 openapi/uploads/**
 lib/tasks/**.csv
 env.list
 build
+.vscode
+
+### Ruby ###
+.ruby-gemset
+
+### NPM & NODE ###
+.npm
+node_modules
+*.log
+npm-debug.log*
+.eslintcache
+
+### Testing, Istanbul ###
+coverage
+*.lcov
+.coveralls.yml
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux,windows,macOS
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux,windows,macOS
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/linux,windows,macOS


### PR DESCRIPTION
Actually I only wanted to add `.vscode` to the .gitignore list, but did a little bit more.

- ignore standard temporary files for Linux, Mac and Windows (I found out that this never hurts, I have it in my global .gitignore but why not add it to a public repository)
- added missing npm cache and eslint cache (they should be normally in node_module if you run them locally but in a monorepo setup they tend to leak outside)
- added .vscode

You may want to keep it simple, so I can revert the changes and only add `.vscode`.

Cheers
Hannes