### PR TITLE
Add iconic_taxon_name to observations.taxonomy response

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Our API is documented using the [Swagger](http://swagger.io/)/[OpenAPI](https://
 npm install
 # Fill in vals to connect to Rails, Postgres, and elasticsearch
 cp config_example.js config.js
-# Run the node app on port 4000
-node app.js
+# Run the node app on port 4000. NODE_ENV is required, so you'll need to set
+# it here or elsewhere in your environment
+NODE_ENV=development node app.js
 ```
 
 # Running Tests

--- a/config_example.js
+++ b/config_example.js
@@ -18,6 +18,9 @@ module.exports = {
     host: INAT_ES_HOST ? `http://${INAT_ES_HOST}:9200` : "http://localhost:9200",
     geoPointField: "location"
   },
+  // Note that the database name will be inferred from the NODE_ENV
+  // environment variable, e.g. `inaturalist_${process.env.NODE_ENV}`, or it
+  // be set explicitly with process.env.INAT_DB_NAME
   database: {
     user: INAT_DB_USER || "inaturalist",
     host: INAT_DB_HOST || "127.0.0.1",

--- a/lib/models/taxon.js
+++ b/lib/models/taxon.js
@@ -540,9 +540,10 @@ const Taxon = class Taxon extends Model {
     const taxonIDs = _.map( taxa, "id" );
     if ( _.isEmpty( taxonIDs ) ) { return; }
     const query = squel.select( )
-      .field( "id, name, rank, rank_level, ancestry, is_active" )
+      .field( "taxa.id, taxa.name, taxa.rank, taxa.rank_level, taxa.ancestry, taxa.is_active, iconic_taxa.name AS iconic_taxon_name" )
       .from( "taxa" )
-      .where( "id IN ?", util.paramArray( taxonIDs ) );
+      .join( "taxa iconic_taxa", null, "taxa.iconic_taxon_id = iconic_taxa.id" )
+      .where( "taxa.id IN ?", util.paramArray( taxonIDs ) );
     const result = await pgClient.query( query.toString( ) );
     const taxonDetails = { };
     _.each( result.rows, row => {


### PR DESCRIPTION
This would allow me to use the iconic_taxon_name to provide some flexibility to translators. In Russian and Ukrainian there are different words for "phylum" depending on whether they are plants or animals, so this would allow us to provide `iconic_taxon` as an inflection for translation keys like `ranks.x_phyla` that we use on the Lifelists in the Rails app, e.g. `@iconic_taxon{Plantae:отдел|Fungi:отдел|Animalia:Тип|Aves:Тип|one Тип / отдел}` (they would need to customize the rest of the animals too).

My main unknown is whether adding this join is a performance risk.