### PR TITLE
fix: allow User-Agent with CORS

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -137,7 +137,7 @@ const util = class util {
     res.header( "Access-Control-Allow-Origin", "*" );
     res.header( "Access-Control-Allow-Headers",
       "Origin, X-Requested-With, Content-Type, Accept, Authorization, Access-Control-Allow-Methods, "
-      + "X-Installation-ID, X-Via, X-HTTP-Method-Override" );
+      + "X-Installation-ID, X-Via, X-HTTP-Method-Override, User-Agent" );
     res.header( "Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE" );
     next( );
   }


### PR DESCRIPTION
This pull request addresses the issue outlined here: https://github.com/inaturalist/iNaturalistAPI/issues/391

While the issue arises from a unique combination of Firefox, client-side JavaScript, and a misunderstanding about the use of the user-agent, it doesn't necessarily require a code change. The user-agent is typically replaced by the browser (also true for Firefox), but Firefox requires all headers to be present when explicitly given.

However, to prevent future confusion and potential issue requests, I propose a harmless fix by adding it to the allowed headers as I'm not aware that the user agent is used in any way other than logging.

Alternatively, and perhaps more effectively, one could update the documentation. Specifically, replace the `user-agent` entry in the API recommended practices with `X-Via`, or add a note clarifying that setting the user-agent is not necessary for a client-side library. https://www.inaturalist.org/pages/api+recommended+practices

Cheers
Hannes
