### PR TITLE
fix: obs search reqs w/ spatial params should not return cached data

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -426,6 +426,13 @@ const util = class util {
     }
     const cacheableParams = { };
     cacheableParams.placeID = queryDup.place_id ? queryDup.place_id : null;
+    cacheableParams.lat = typeof ( queryDup.lat ) === "undefined" ? null : queryDup.lat;
+    cacheableParams.lng = typeof ( queryDup.lng ) === "undefined" ? null : queryDup.lng;
+    cacheableParams.radius = typeof ( queryDup.radius ) === "undefined" ? null : queryDup.radius;
+    cacheableParams.swlat = typeof ( queryDup.swlat ) === "undefined" ? null : queryDup.swlat;
+    cacheableParams.swlng = typeof ( queryDup.swlng ) === "undefined" ? null : queryDup.swlng;
+    cacheableParams.nelat = typeof ( queryDup.nelat ) === "undefined" ? null : queryDup.nelat;
+    cacheableParams.nelng = typeof ( queryDup.nelng ) === "undefined" ? null : queryDup.nelng;
     cacheableParams.verifiable = queryDup.verifiable ? queryDup.verifiable : null;
     cacheableParams.qualityGrade = queryDup.quality_grade ? queryDup.quality_grade : null;
     cacheableParams.spam = queryDup.spam ? queryDup.spam : null;
@@ -491,16 +498,18 @@ const util = class util {
     if ( queryDup.order_by === "" ) {
       delete queryDup.order_by;
     }
-    if ( _.isEmpty( queryDup.lat ) && _.isEmpty( queryDup.lat ) ) {
-      delete queryDup.lat;
-      delete queryDup.lng;
-      delete queryDup.radius;
-    }
+    if ( typeof ( lat ) === "undefined" ) delete queryDup.lat;
+    if ( typeof ( lng ) === "undefined" ) delete queryDup.lng;
+    if ( typeof ( radius ) === "undefined" ) delete queryDup.radius;
+    if ( typeof ( nelat ) === "undefined" ) delete queryDup.nelat;
+    if ( typeof ( nelng ) === "undefined" ) delete queryDup.nelng;
+    if ( typeof ( swlat ) === "undefined" ) delete queryDup.swlat;
+    if ( typeof ( swlng ) === "undefined" ) delete queryDup.swlng;
     // only cacheable params are present, so generate a cache key
     if ( _.isEmpty( queryDup ) && _.isEmpty( reqInatDup ) ) {
       fileCacheKey = `${prefix}`;
       _.each( cacheableParams, ( v, k ) => {
-        if ( v && !( k === "perPage" && options.ignorePagination ) ) {
+        if ( v !== null && v !== undefined && !( k === "perPage" && options.ignorePagination ) ) {
           fileCacheKey += `-${k}-${v}`;
         }
       } );

--- a/lib/util.js
+++ b/lib/util.js
@@ -426,13 +426,6 @@ const util = class util {
     }
     const cacheableParams = { };
     cacheableParams.placeID = queryDup.place_id ? queryDup.place_id : null;
-    cacheableParams.lat = typeof ( queryDup.lat ) === "undefined" ? null : queryDup.lat;
-    cacheableParams.lng = typeof ( queryDup.lng ) === "undefined" ? null : queryDup.lng;
-    cacheableParams.radius = typeof ( queryDup.radius ) === "undefined" ? null : queryDup.radius;
-    cacheableParams.swlat = typeof ( queryDup.swlat ) === "undefined" ? null : queryDup.swlat;
-    cacheableParams.swlng = typeof ( queryDup.swlng ) === "undefined" ? null : queryDup.swlng;
-    cacheableParams.nelat = typeof ( queryDup.nelat ) === "undefined" ? null : queryDup.nelat;
-    cacheableParams.nelng = typeof ( queryDup.nelng ) === "undefined" ? null : queryDup.nelng;
     cacheableParams.verifiable = queryDup.verifiable ? queryDup.verifiable : null;
     cacheableParams.qualityGrade = queryDup.quality_grade ? queryDup.quality_grade : null;
     cacheableParams.spam = queryDup.spam ? queryDup.spam : null;
@@ -498,13 +491,7 @@ const util = class util {
     if ( queryDup.order_by === "" ) {
       delete queryDup.order_by;
     }
-    if ( typeof ( lat ) === "undefined" ) delete queryDup.lat;
-    if ( typeof ( lng ) === "undefined" ) delete queryDup.lng;
-    if ( typeof ( radius ) === "undefined" ) delete queryDup.radius;
-    if ( typeof ( nelat ) === "undefined" ) delete queryDup.nelat;
-    if ( typeof ( nelng ) === "undefined" ) delete queryDup.nelng;
-    if ( typeof ( swlat ) === "undefined" ) delete queryDup.swlat;
-    if ( typeof ( swlng ) === "undefined" ) delete queryDup.swlng;
+
     // only cacheable params are present, so generate a cache key
     if ( _.isEmpty( queryDup ) && _.isEmpty( reqInatDup ) ) {
       fileCacheKey = `${prefix}`;

--- a/test/util.js
+++ b/test/util.js
@@ -165,7 +165,7 @@ describe( "util", ( ) => {
     } );
   } );
 
-  describe( "observationSearchRequestCacheKey", ( ) => {
+  describe.only( "observationSearchRequestCacheKey", ( ) => {
     it( "returns a cache key for cacheable queries", ( ) => {
       const req = {
         query: {
@@ -193,42 +193,6 @@ describe( "util", ( ) => {
       expectParamInCacheKey( "place_id", 1, "placeID" );
     } );
 
-    it( "allows queries with lat to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "lat", 1, "lat" );
-    } );
-
-    it( "allows queries with lng to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "lng", 1, "lng" );
-    } );
-
-    it( "allows queries with radius to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "radius", 1, "radius" );
-    } );
-
-    it( "allows queries with swlat to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "swlat", 1, "swlat" );
-    } );
-
-    it( "allows queries with swlng to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "swlng", 1, "swlng" );
-    } );
-
-    it( "allows queries with nelat to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "nelat", 1, "nelat" );
-    } );
-
-    it( "allows queries with nelng to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "nelng", 1, "nelng" );
-    } );
-
-    it( "allows queries with lat of 0 to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "lat", 0, "lat" );
-    } );
-
-    it( "allows queries with nelat of 0 to be cached for obs search", ( ) => {
-      expectParamInCacheKey( "nelat", 0, "nelat" );
-    } );
-
     it( "does not allow queries with place_id to be cached for obs search when logged in", ( ) => {
       const req = {
         query: {
@@ -242,6 +206,21 @@ describe( "util", ( ) => {
         enableInTestEnv: true
       } ) ).to.be.null;
     } );
+
+    function expectParamNotToGenerateCacheKey( paramKey, paramValue ) {
+      const req = { query: { [paramKey]: paramValue } };
+      expect( util.observationSearchRequestCacheKey( req, "ObservationsController.search", {
+        enableInTestEnv: true
+      } ) ).to.be.null;
+    }
+
+    it( "should not generate a key if lat in params", ( ) => expectParamNotToGenerateCacheKey( "lat", 1 ) );
+    it( "should not generate a key if lng in params", ( ) => expectParamNotToGenerateCacheKey( "lng", 1 ) );
+    it( "should not generate a key if radius in params", ( ) => expectParamNotToGenerateCacheKey( "radius", 1 ) );
+    it( "should not generate a key if swlat in params", ( ) => expectParamNotToGenerateCacheKey( "swlat", 1 ) );
+    it( "should not generate a key if swlng in params", ( ) => expectParamNotToGenerateCacheKey( "swlng", 1 ) );
+    it( "should not generate a key if nelat in params", ( ) => expectParamNotToGenerateCacheKey( "nelat", 1 ) );
+    it( "should not generate a key if nelng in params", ( ) => expectParamNotToGenerateCacheKey( "nelng", 1 ) );
 
     it( "includes locale in cache key for obs search by default", ( ) => {
       const req = {

--- a/test/util.js
+++ b/test/util.js
@@ -165,7 +165,7 @@ describe( "util", ( ) => {
     } );
   } );
 
-  describe.only( "observationSearchRequestCacheKey", ( ) => {
+  describe( "observationSearchRequestCacheKey", ( ) => {
     it( "returns a cache key for cacheable queries", ( ) => {
       const req = {
         query: {

--- a/test/util.js
+++ b/test/util.js
@@ -178,15 +178,55 @@ describe( "util", ( ) => {
       } ) ).to.eq( "ObservationsController.search-returnBounds-true" );
     } );
 
-    it( "allows queries with place_id to be cached for obs search", ( ) => {
+    function expectParamInCacheKey( paramKey, paramVal, paramCacheKey ) {
       const req = {
         query: {
-          place_id: 1
+          [paramKey]: paramVal
         }
       };
       expect( util.observationSearchRequestCacheKey( req, "ObservationsController.search", {
         enableInTestEnv: true
-      } ) ).to.eq( "ObservationsController.search-placeID-1" );
+      } ) ).to.eq( `ObservationsController.search-${paramCacheKey}-${paramVal}` );
+    }
+
+    it( "allows queries with place_id to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "place_id", 1, "placeID" );
+    } );
+
+    it( "allows queries with lat to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "lat", 1, "lat" );
+    } );
+
+    it( "allows queries with lng to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "lng", 1, "lng" );
+    } );
+
+    it( "allows queries with radius to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "radius", 1, "radius" );
+    } );
+
+    it( "allows queries with swlat to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "swlat", 1, "swlat" );
+    } );
+
+    it( "allows queries with swlng to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "swlng", 1, "swlng" );
+    } );
+
+    it( "allows queries with nelat to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "nelat", 1, "nelat" );
+    } );
+
+    it( "allows queries with nelng to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "nelng", 1, "nelng" );
+    } );
+
+    it( "allows queries with lat of 0 to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "lat", 0, "lat" );
+    } );
+
+    it( "allows queries with nelat of 0 to be cached for obs search", ( ) => {
+      expectParamInCacheKey( "nelat", 0, "nelat" );
     } );
 
     it( "does not allow queries with place_id to be cached for obs search when logged in", ( ) => {


### PR DESCRIPTION
The symptom was that iNat Next was showing global results in Explore when it should have been showing Nearby... sometimes and not others.

I'm not sure if this is actually what we want (no caching for these params), but this will fix the bug. If we do want caching with those params, that wasn't working either, but it's a simple fix.