### PR TITLE
Increase max request size to 2 MB

### DIFF
--- a/lib/inaturalist_api.js
+++ b/lib/inaturalist_api.js
@@ -23,6 +23,7 @@ InaturalistAPI.prepareApp = ( ) => {
   const server = express( );
   server.use( compression( ) );
   server.use( bodyParser.json( {
+    limit: '2mb',
     type: req => {
       // Parser the request body for everything other than multipart requests,
       // which should specify body data as plain old form data which express can


### PR DESCRIPTION
In service of https://github.com/inaturalist/inaturalist/issues/3820
See also https://github.com/inaturalist/inaturalistjs/pull/83

Even when encoded as JSON, an update to a project with over 1000 rules will top out over the [default maximum request size](https://github.com/expressjs/body-parser/blob/966bc9dd141cae791d5634a46af58435327b3170/README.md#L140-L145) of 100kB.