### PR TITLE
feat: localize wikipedia_url in taxon responses

### DIFF
--- a/lib/models/taxon.js
+++ b/lib/models/taxon.js
@@ -454,7 +454,7 @@ const Taxon = class Taxon extends Model {
     const ids = _.compact( _.map( taxa, "id" ) );
     if ( _.isEmpty( ids ) ) { return; }
     const query = squel.select( )
-      .field( "t.id, t.wikipedia_summary, td.locale, td.body" )
+      .field( "t.id, t.wikipedia_summary, t.wikipedia_title, t.name, td.locale, td.body, td.url" )
       .from( "taxa t" )
       .left_join( "taxon_descriptions td", null, "t.id = td.taxon_id" )
       .where( "t.id IN ?", ids );
@@ -463,9 +463,17 @@ const Taxon = class Taxon extends Model {
     _.each( rows, r => {
       byTaxonID[r.id] = byTaxonID[r.id] || [];
       if ( r.body ) {
-        byTaxonID[r.id].push( { locale: r.locale.toLowerCase( ), body: r.body } );
+        byTaxonID[r.id].push( {
+          locale: r.locale.toLowerCase( ),
+          body: r.body,
+          url: r.url
+        } );
       }
-      byTaxonID[r.id].push( { locale: "en", body: r.wikipedia_summary } );
+      byTaxonID[r.id].push( {
+        locale: "en",
+        body: r.wikipedia_summary,
+        url: `https://en.wikipedia.org/wiki/${r.wikipedia_title || r.name}`
+      } );
     } );
     _.each( _.compact( taxa ), t => {
       if ( byTaxonID[t.id] ) {
@@ -474,10 +482,14 @@ const Taxon = class Taxon extends Model {
           const localePrefix = options.locale.split( "-" )[0];
           summary = _.find( byTaxonID[t.id], d => _.startsWith( d.locale, `${localePrefix}` ) );
         }
-        if ( summary ) { t.wikipedia_summary = summary.body; }
+        if ( summary ) {
+          t.wikipedia_summary = summary.body;
+          t.wikipedia_url = summary.url;
+        }
       }
       if ( !t.wikipedia_summary || t.wikipedia_summary.match( /^\d\d\d\d-\d\d-\d\d$/ ) ) {
         t.wikipedia_summary = null;
+        t.wikipedia_url = null;
       }
     } );
   }


### PR DESCRIPTION
This uses the `url` in `taxon_descriptions` just like we're using the `body` for the `wikipedia_summary`. Also related to https://github.com/inaturalist/iNaturalistReactNative/issues/2101