### PR TITLE
Taxon Photos Index

### DIFF
--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -228,6 +228,11 @@ const ComputervisionController = class ComputervisionController {
       formData.append( "lat", req.body.lat );
       formData.append( "lng", req.body.lng );
     }
+    if ( req.userSession?.isAdmin && (
+      req.body.include_representative_photos || req.query.include_representative_photos
+    ) ) {
+      formData.append( "return_embedding", "true" );
+    }
 
     const requestAbortController = new AbortController( );
     const requestTimeout = setTimeout( ( ) => {
@@ -267,57 +272,56 @@ const ComputervisionController = class ComputervisionController {
     if ( _.isEmpty( embedding ) ) {
       return;
     }
-    const taxonIDsToLookup = _.map( _.filter(
+    const resultsToLookup = _.filter(
       results, result => result?.taxon?.rank_level < 30
-    ), result => result?.taxon?.id );
-    if ( _.isEmpty( taxonIDsToLookup ) ) {
+    );
+    if ( _.isEmpty( resultsToLookup ) ) {
       return;
     }
-    const embeddingsResponse = await esClient.search( "taxon_photos", {
-      body: {
-        query: {
-          bool: {
-            filter: [
-              { terms: { taxon_ids: taxonIDsToLookup } }
+
+    const representativeTaxonPhotos = [];
+    const representativeTaxonPhotosIDs = [];
+    const promiseProducer = ( ) => {
+      if ( _.isEmpty( resultsToLookup ) ) {
+        return null;
+      }
+      const resultToLookup = resultsToLookup.shift( );
+      return ( async ( ) => {
+        const embeddingsResponse = await esClient.search( "taxon_photos", {
+          body: {
+            knn: {
+              field: "embedding",
+              query_vector: embedding,
+              k: 10,
+              num_candidates: 10,
+              filter: {
+                term: {
+                  ancestor_ids: resultToLookup.taxon.id
+                }
+              }
+            },
+            size: 1,
+            _source: [
+              "id",
+              "taxon_id",
+              "photo_id",
+              "ancestor_ids"
             ]
           }
-        },
-        knn: {
-          field: "embedding",
-          query_vector: embedding,
-          k: 500,
-          num_candidates: 5000
-        },
-        size: 500,
-        _source: [
-          "id",
-          "taxon_id",
-          "photo_id",
-          "ancestor_ids"
-        ]
-      }
-    } );
-    const embeddingsHits = _.map( embeddingsResponse.hits.hits, "_source" );
-    // TODO: remove this once the ancestor_ids data in the index has been fixed
-    _.each( embeddingsHits, hit => {
-      hit.ancestor_ids = _.filter( hit.ancestor_ids, ancestorID => ancestorID !== hit.id );
-      hit.ancestor_ids.push( hit.taxon_id );
-    } );
-    const representativeTaxonPhotos = [];
-    _.each( results, result => {
-      if ( result && result.taxon && result.taxon.default_photo ) {
-        const firstMatch = _.find( embeddingsHits, h => (
-          h?.photo_id && _.includes( h.ancestor_ids, result.taxon.id )
-        ) );
-        if ( !firstMatch ) {
+        } );
+        const firstHitSource = embeddingsResponse.hits.hits[0]?._source;
+        if ( !firstHitSource ) {
           return;
         }
         representativeTaxonPhotos.push( {
-          taxon: result.taxon,
-          photo_id: firstMatch.photo_id
+          taxon: resultToLookup.taxon,
+          photo_id: firstHitSource.photo_id
         } );
-      }
-    } );
+      } )( );
+    };
+    const pool = new PromisePool( promiseProducer, 2 );
+    await pool.start( );
+
     await ObservationPreload.assignObservationPhotoPhotos( representativeTaxonPhotos );
     _.each( representativeTaxonPhotos, taxonPhoto => {
       if ( taxonPhoto?.photo?.url ) {

--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -303,18 +303,27 @@ const ComputervisionController = class ComputervisionController {
       hit.ancestor_ids = _.remove( hit.ancestor_ids, ancestorID => ancestorID === hit.id );
       hit.ancestor_ids.push( hit.taxon_id );
     } );
-    await ObservationPreload.assignObservationPhotoPhotos( embeddingsHits );
+    const representativeTaxonPhotos = [];
     _.each( results, result => {
       if ( result && result.taxon && result.taxon.default_photo ) {
         const firstMatch = _.find( embeddingsHits, h => (
-          h?.photo?.url
-            && _.includes( h.ancestor_ids, result.taxon.id )
+          h?.photo_id && _.includes( h.ancestor_ids, result.taxon.id )
         ) );
-        if ( firstMatch ) {
-          result.taxon.default_photo.url = firstMatch.photo.url.replace( "medium", "square" );
-          result.taxon.default_photo.medium_url = firstMatch.photo.url;
-          result.taxon.default_photo.square_url = firstMatch.photo.url.replace( "medium", "square" );
+        if ( !firstMatch ) {
+          return;
         }
+        representativeTaxonPhotos.push( {
+          taxon: result.taxon,
+          photo_id: firstMatch.photo_id
+        } );
+      }
+    } );
+    await ObservationPreload.assignObservationPhotoPhotos( representativeTaxonPhotos );
+    _.each( representativeTaxonPhotos, taxonPhoto => {
+      if ( taxonPhoto?.photo?.url ) {
+        taxonPhoto.taxon.default_photo.url = taxonPhoto.photo.url.replace( "medium", "square" );
+        taxonPhoto.taxon.default_photo.medium_url = taxonPhoto.photo.url;
+        taxonPhoto.taxon.default_photo.square_url = taxonPhoto.photo.url.replace( "medium", "square" );
       }
     } );
   }

--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -280,7 +280,6 @@ const ComputervisionController = class ComputervisionController {
     }
 
     const representativeTaxonPhotos = [];
-    const representativeTaxonPhotosIDs = [];
     const promiseProducer = ( ) => {
       if ( _.isEmpty( resultsToLookup ) ) {
         return null;

--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -7,6 +7,7 @@ const PromisePool = require( "es6-promise-pool" );
 const csv = require( "fast-csv" );
 const crypto = require( "crypto" );
 const pgClient = require( "../../pg_client" );
+const esClient = require( "../../es_client" );
 const TaxaController = require( "./taxa_controller" );
 const InaturalistAPI = require( "../../inaturalist_api" );
 const config = require( "../../../config" );
@@ -262,6 +263,62 @@ const ComputervisionController = class ComputervisionController {
     return scores;
   }
 
+  static async addRepresentativePhotos( results, embedding ) {
+    if ( _.isEmpty( embedding ) ) {
+      return;
+    }
+    const taxonIDsToLookup = _.map( _.filter(
+      results, result => result.rank_level < 30
+    ), "taxon_id" );
+    if ( _.isEmpty( taxonIDsToLookup ) ) {
+      return;
+    }
+    const embeddingsResponse = await esClient.search( "taxon_photos", {
+      body: {
+        query: {
+          bool: {
+            filter: [
+              { terms: { taxon_ids: taxonIDsToLookup } }
+            ]
+          }
+        },
+        knn: {
+          field: "embedding",
+          query_vector: embedding,
+          k: 10,
+          num_candidates: 500
+        },
+        size: 10000,
+        _source: [
+          "id",
+          "taxon_id",
+          "photo_id",
+          "ancestor_ids"
+        ]
+      }
+    } );
+    const embeddingsHits = _.map( embeddingsResponse.hits.hits, "_source" );
+    // TODO: remove this once the ancestor_ids data in the index has been fixed
+    _.each( embeddingsHits, hit => {
+      hit.ancestor_ids = _.remove( hit.ancestor_ids, ancestorID => ancestorID === hit.id );
+      hit.ancestor_ids.push( hit.taxon_id );
+    } );
+    await ObservationPreload.assignObservationPhotoPhotos( embeddingsHits );
+    _.each( results, result => {
+      if ( result && result.taxon && result.taxon.default_photo ) {
+        const firstMatch = _.find( embeddingsHits, h => (
+          h?.photo?.url
+            && _.includes( h.ancestor_ids, result.taxon.id )
+        ) );
+        if ( firstMatch ) {
+          result.taxon.default_photo.url = firstMatch.photo.url.replace( "medium", "square" );
+          result.taxon.default_photo.medium_url = firstMatch.photo.url;
+          result.taxon.default_photo.square_url = firstMatch.photo.url.replace( "medium", "square" );
+        }
+      }
+    } );
+  }
+
   static async delegatedScoresProcessing( req, visionApiResponse ) {
     const localeOpts = util.localeOpts( req );
     const prepareTaxon = t => {
@@ -312,12 +369,18 @@ const ComputervisionController = class ComputervisionController {
     } );
 
     await ESModel.fetchBelongsTo( withTaxa, Taxon, taxonOpts );
-    await Taxon.preloadIntoTaxonPhotos( _.map( withTaxa, "taxon" ), { localeOpts } );
+    await Taxon.preloadIntoTaxonPhotos( _.map( _.filter( withTaxa, "taxon" ), "taxon" ), { localeOpts } );
+
     if ( !( req.body.aggregated || req.query.aggregated ) ) {
       _.each( withTaxa, s => {
         delete s.taxon_id;
       } );
     }
+
+    await ComputervisionController.addRepresentativePhotos(
+      withTaxa,
+      visionApiResponse.embedding
+    );
 
     // remove attributes of common_ancestor that should not be in the response
     if ( response.common_ancestor ) {

--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -268,8 +268,8 @@ const ComputervisionController = class ComputervisionController {
       return;
     }
     const taxonIDsToLookup = _.map( _.filter(
-      results, result => result.rank_level < 30
-    ), "taxon_id" );
+      results, result => result?.taxon?.rank_level < 30
+    ), result => result?.taxon?.id );
     if ( _.isEmpty( taxonIDsToLookup ) ) {
       return;
     }
@@ -285,10 +285,10 @@ const ComputervisionController = class ComputervisionController {
         knn: {
           field: "embedding",
           query_vector: embedding,
-          k: 10,
-          num_candidates: 500
+          k: 500,
+          num_candidates: 5000
         },
-        size: 10000,
+        size: 500,
         _source: [
           "id",
           "taxon_id",
@@ -300,7 +300,7 @@ const ComputervisionController = class ComputervisionController {
     const embeddingsHits = _.map( embeddingsResponse.hits.hits, "_source" );
     // TODO: remove this once the ancestor_ids data in the index has been fixed
     _.each( embeddingsHits, hit => {
-      hit.ancestor_ids = _.remove( hit.ancestor_ids, ancestorID => ancestorID === hit.id );
+      hit.ancestor_ids = _.filter( hit.ancestor_ids, ancestorID => ancestorID !== hit.id );
       hit.ancestor_ids.push( hit.taxon_id );
     } );
     const representativeTaxonPhotos = [];
@@ -321,9 +321,7 @@ const ComputervisionController = class ComputervisionController {
     await ObservationPreload.assignObservationPhotoPhotos( representativeTaxonPhotos );
     _.each( representativeTaxonPhotos, taxonPhoto => {
       if ( taxonPhoto?.photo?.url ) {
-        taxonPhoto.taxon.default_photo.url = taxonPhoto.photo.url.replace( "medium", "square" );
-        taxonPhoto.taxon.default_photo.medium_url = taxonPhoto.photo.url;
-        taxonPhoto.taxon.default_photo.square_url = taxonPhoto.photo.url.replace( "medium", "square" );
+        taxonPhoto.taxon.representative_photo = taxonPhoto.photo;
       }
     } );
   }
@@ -386,10 +384,14 @@ const ComputervisionController = class ComputervisionController {
       } );
     }
 
-    await ComputervisionController.addRepresentativePhotos(
-      withTaxa,
-      visionApiResponse.embedding
-    );
+    if ( req.userSession?.isAdmin && (
+      req.body.include_representative_photos || req.query.include_representative_photos
+    ) ) {
+      await ComputervisionController.addRepresentativePhotos(
+        withTaxa,
+        visionApiResponse.embedding
+      );
+    }
 
     // remove attributes of common_ancestor that should not be in the response
     if ( response.common_ancestor ) {


### PR DESCRIPTION
- Given a parameter `include_representative_photos`, CV endpoints may return an additional taxon attribute `representative_photo` containing photo metadata for taxon photo visually similar to the evaluated photo. For admins only currently