### PR TITLE
Reduce projects queries

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -635,6 +635,24 @@ ObservationsController.umbrellasContainingObsTraditionalProjects = async obs => 
 // reverse of the normal query of figuring out which observations belong in one
 // of those projects
 ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
+  if ( !obs.user ) {
+    return [];
+  }
+
+  const newStyleProjectMembership = await User.newStyleProjectMembership( obs.user.id );
+  const observerCollectionMembership = _.filter( newStyleProjectMembership, membership => (
+    membership.project_type === "collection"
+  ) );
+  const observerUmbrellaMembership = _.filter( newStyleProjectMembership, membership => (
+    membership.project_type === "umbrella"
+  ) );
+  if ( _.isEmpty( newStyleProjectMembership ) ) {
+    return [];
+  }
+
+  let joinedCollectionProjectIDs = [];
+  let joinedUmbrellaIDs = [];
+
   const obsSearchParams = { };
   obsSearchParams.user_id = obs.user ? obs.user.id : null;
   obsSearchParams.taxon_id = obs.taxon ? obs.taxon.ancestor_ids : null;
@@ -660,51 +678,55 @@ ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
   const { filters, inverseFilters } = ObservationsController
     .projectQueryFromObsSearchParams( obsSearchParams );
 
-  // Lookup relevant collections the observer has joined
-  const collectionsQuery = {
-    filters: filters.concat( [esClient.termFilter( "user_ids", obs.user.id )] ),
-    inverse_filters: inverseFilters,
-    size: 1000,
-    _source: ["id"]
-  };
-  const joinedCollectionsResponse = await ESModel.elasticResults(
-    { query: { } }, collectionsQuery, "projects"
-  );
-  let joinedCollectionProjectIDs = _.map( joinedCollectionsResponse.hits.hits, "_source.id" );
-
-  // lookup relevant, joined, umbrellas
-  let joinedUmbrellaIDs = [];
-  // fetch the umbrella IDs that contain any matching collection - not just
-  // the collections the user has joined as they may have joined the umbrella only
-  const collectionUmbrellasQuery = {
-    filters: filters.concat( [{ exists: { field: "umbrella_project_ids" } }] ),
-    inverse_filters: inverseFilters,
-    size: 10000,
-    _source: ["umbrella_project_ids"]
-  };
-  const collectionUmbrellasResponse = await ESModel.elasticResults(
-    { query: { } }, collectionUmbrellasQuery, "projects"
-  );
-  let umbrellaProjectIDs = _.uniq( _.flatten( _.map(
-    collectionUmbrellasResponse.hits.hits, "_source.umbrella_project_ids"
-  ) ) );
-  // add to the initial list of umbrella projects those which contain the obs' traditional projects
-  const umbrellasFromTraditional = await ObservationsController
-    .umbrellasContainingObsTraditionalProjects( obs );
-  umbrellaProjectIDs = umbrellaProjectIDs.concat( umbrellasFromTraditional );
-  // fetch the matching umbrella IDs the user has actually joined
-  if ( !_.isEmpty( umbrellaProjectIDs ) ) {
-    const umbrellaProjectsQuery = {
-      filters: [
-        { term: { project_type: "umbrella" } },
-        { terms: { id: umbrellaProjectIDs } },
-        { term: { user_ids: obs.user.id } }
-      ],
-      size: 100,
+  if ( !_.isEmpty( observerCollectionMembership ) ) {
+    // Lookup relevant collections the observer has joined
+    const collectionsQuery = {
+      filters: filters.concat( [esClient.termFilter( "user_ids", obs.user.id )] ),
+      inverse_filters: inverseFilters,
+      size: 1000,
       _source: ["id"]
     };
-    const umbrellaData = await ESModel.elasticResults( { query: { } }, umbrellaProjectsQuery, "projects" );
-    joinedUmbrellaIDs = _.map( umbrellaData.hits.hits, "_source.id" );
+    const joinedCollectionsResponse = await ESModel.elasticResults(
+      { query: { } }, collectionsQuery, "projects"
+    );
+    joinedCollectionProjectIDs = _.map( joinedCollectionsResponse.hits.hits, "_source.id" );
+  }
+
+  if ( !_.isEmpty( observerUmbrellaMembership ) ) {
+    // lookup relevant, joined, umbrellas
+    // fetch the umbrella IDs that contain any matching collection - not just
+    // the collections the user has joined as they may have joined the umbrella only
+    const collectionUmbrellasQuery = {
+      filters: filters.concat( [{ exists: { field: "umbrella_project_ids" } }] ),
+      inverse_filters: inverseFilters,
+      size: 10000,
+      _source: ["umbrella_project_ids"]
+    };
+    const collectionUmbrellasResponse = await ESModel.elasticResults(
+      { query: { } }, collectionUmbrellasQuery, "projects"
+    );
+    let umbrellaProjectIDs = _.uniq( _.flatten( _.map(
+      collectionUmbrellasResponse.hits.hits, "_source.umbrella_project_ids"
+    ) ) );
+    // add to the initial list of umbrella projects those which contain
+    // the obs' traditional projects
+    const umbrellasFromTraditional = await ObservationsController
+      .umbrellasContainingObsTraditionalProjects( obs );
+    umbrellaProjectIDs = umbrellaProjectIDs.concat( umbrellasFromTraditional );
+    // fetch the matching umbrella IDs the user has actually joined
+    if ( !_.isEmpty( umbrellaProjectIDs ) ) {
+      const umbrellaProjectsQuery = {
+        filters: [
+          { term: { project_type: "umbrella" } },
+          { terms: { id: umbrellaProjectIDs } },
+          { term: { user_ids: obs.user.id } }
+        ],
+        size: 100,
+        _source: ["id"]
+      };
+      const umbrellaData = await ESModel.elasticResults( { query: { } }, umbrellaProjectsQuery, "projects" );
+      joinedUmbrellaIDs = _.map( umbrellaData.hits.hits, "_source.id" );
+    }
   }
   // if the obs is obscured AND the viewer is the observer OR the viewer curates collection projects
   if (

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -296,6 +296,17 @@ const User = class User extends Model {
     return _.map( rows, "project_id" );
   }
 
+  static async newStyleProjectMembership( userID ) {
+    const query = squel.select( )
+      .field( "projects.id, projects.project_type, project_users.role" )
+      .from( "project_users" )
+      .join( "projects", null, "project_users.project_id = projects.id" )
+      .where( "project_users.user_id = ?", userID )
+      .where( "project_type IN ?", ["collection", "umbrella"] );
+    const { rows } = await pgClient.replica.query( query.toString( ) );
+    return rows;
+  }
+
   static async trustingUsers( userID ) {
     const query = squel.select( ).field( "user_id" ).from( "friendships" )
       .where( "friend_id = ?", userID )


### PR DESCRIPTION
For observation requests that include the `include_new_projects` parameter:
  - do not attempt to look up collection projects if the observer has not joined any
  - do not attempt to look up umbrella projects if the observer has not joined any

Few observers have joined collection or umbrella projects. We only display non-traditional projects the user has joined. This change is to perform a membership query before attempting the more complicated observation inclusion query, and to skip the more complicated query if we know the results are not relevant to the given observation/observer.