### PR TITLE
alternate observation collection project lookup

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -613,20 +613,13 @@ ObservationsController.umbrellasContainingObsTraditionalProjects = async obs => 
   if ( _.isEmpty( obs.project_ids ) ) {
     return [];
   }
-  const umbrellasQuery = {
-    filters: [{
-      terms: { id: obs.project_ids }
-    }, {
-      exists: { field: "umbrella_project_ids" }
-    }],
-    size: 10000,
-    _source: ["umbrella_project_ids"]
-  };
-  const collectionUmbrellasResponse = await ESModel.elasticResults(
-    { query: { } }, umbrellasQuery, "projects"
-  );
+  const { docs: traditionalProjects } = await esClient.mget( obs.project_ids, "projects", {
+    source: util.sourceParams( [
+      "umbrella_project_ids"
+    ] )
+  } );
   return _.uniq( _.flatten( _.map(
-    collectionUmbrellasResponse.hits.hits, "_source.umbrella_project_ids"
+    traditionalProjects, "_source.umbrella_project_ids"
   ) ) );
 };
 
@@ -650,8 +643,7 @@ ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
     return [];
   }
 
-  let joinedCollectionProjectIDs = [];
-  let joinedUmbrellaIDs = [];
+  const joinedCollectionProjectIDs = _.map( observerCollectionMembership, "id" );
 
   const obsSearchParams = { };
   obsSearchParams.user_id = obs.user ? obs.user.id : null;
@@ -673,25 +665,31 @@ ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
     obsSearchParams.term_value_id.push( a.controlled_value_id );
   } );
 
+  const { docs: joinedCollectProjectDocs } = await esClient.mget( joinedCollectionProjectIDs, "projects", {
+    source: util.sourceParams( [
+      "id",
+      "title",
+      "slug",
+      "search_parameter_fields",
+      "user_ids"
+    ] )
+  } );
+  const joinedCollectionProjects = _.map( joinedCollectProjectDocs, "_source" );
+  const matchingJoinedCollectionProjects = _.filter( joinedCollectionProjects, project => {
+    if ( _.isEmpty( project.search_parameter_fields ) ) {
+      return false;
+    }
+    return Project.collectionProjectRulesAllowObservation( project, obs );
+  } );
+  let matchingJoinedCollectionProjectIDs = _.map( matchingJoinedCollectionProjects, "id" );
+
   // Establish a base set of filters of all collection projects that could
   // include this obs
   const { filters, inverseFilters } = ObservationsController
     .projectQueryFromObsSearchParams( obsSearchParams );
 
-  if ( !_.isEmpty( observerCollectionMembership ) ) {
-    // Lookup relevant collections the observer has joined
-    const collectionsQuery = {
-      filters: filters.concat( [esClient.termFilter( "user_ids", obs.user.id )] ),
-      inverse_filters: inverseFilters,
-      size: 1000,
-      _source: ["id"]
-    };
-    const joinedCollectionsResponse = await ESModel.elasticResults(
-      { query: { } }, collectionsQuery, "projects"
-    );
-    joinedCollectionProjectIDs = _.map( joinedCollectionsResponse.hits.hits, "_source.id" );
-  }
-
+  // lookup relevant, joined, umbrellas
+  let matchingJoinedUmbrellaProjectIDs = [];
   if ( !_.isEmpty( observerUmbrellaMembership ) ) {
     // lookup relevant, joined, umbrellas
     // fetch the umbrella IDs that contain any matching collection - not just
@@ -725,7 +723,7 @@ ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
         _source: ["id"]
       };
       const umbrellaData = await ESModel.elasticResults( { query: { } }, umbrellaProjectsQuery, "projects" );
-      joinedUmbrellaIDs = _.map( umbrellaData.hits.hits, "_source.id" );
+      matchingJoinedUmbrellaProjectIDs = _.map( umbrellaData.hits.hits, "_source.id" );
     }
   }
   // if the obs is obscured AND the viewer is the observer OR the viewer curates collection projects
@@ -742,18 +740,18 @@ ObservationsController.newProjectsContaining = async ( obs, options = {} ) => {
       ] = await ObservationsController.observationTrustedProjects( obs, obsSearchParams, options );
 
       if ( !_.isEmpty( observationTrustedProjectIDs ) ) {
-        joinedCollectionProjectIDs = _.uniq(
-          joinedCollectionProjectIDs.concat( observationTrustedProjectIDs )
+        matchingJoinedCollectionProjectIDs = _.uniq(
+          matchingJoinedCollectionProjectIDs.concat( observationTrustedProjectIDs )
         );
       }
       if ( !_.isEmpty( trustedUmbrellasContainingCollectionsTrustedImplicitly ) ) {
-        joinedUmbrellaIDs = joinedUmbrellaIDs.concat(
+        matchingJoinedUmbrellaProjectIDs = matchingJoinedUmbrellaProjectIDs.concat(
           trustedUmbrellasContainingCollectionsTrustedImplicitly
         );
       }
     }
   }
-  return joinedCollectionProjectIDs.concat( joinedUmbrellaIDs );
+  return matchingJoinedCollectionProjectIDs.concat( matchingJoinedUmbrellaProjectIDs );
 };
 
 ObservationsController.observationTrustedProjects = async (

--- a/lib/es_client.js
+++ b/lib/es_client.js
@@ -108,7 +108,6 @@ esClient.mget = async ( ids, index, options = { } ) => {
   let mgetParams = {
     preference: config.elasticsearch.preference,
     index: esClient.buildIndexName( index ),
-
     body: { ids }
   };
   if ( !_.isEmpty( options.source ) ) {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -263,6 +263,145 @@ const Project = class Project extends Model {
     await ESModel.fetchBelongsTo( projectRules, Project, { foreignKey: "operand_id" } );
     await ESModel.fetchBelongsTo( controlledTermRules, ControlledTerm, { foreignKey: "value" } );
   }
+
+  static collectionProjectRulesAllowObservation( project, observation ) {
+    const observedTime = observation.time_observed_at
+      ? moment( observation.time_observed_at ).parseZone( ) : null;
+    const observedDate = observation.observed_on
+      ? moment( observation.observed_on ).parseZone( ) : null;
+    return _.every( project.search_parameter_fields, ( value, field ) => {
+      if ( field === "d1" ) {
+        const projectStartMoment = moment( value ).parseZone( );
+        const projectStartIsDate = moment( value, "YYYY-MM-DD", true ).isValid( );
+        if ( !observedTime && !observedDate ) {
+          return false;
+        }
+        if ( !projectStartIsDate ) {
+          // project d1 is time, observed is time
+          if ( observedTime && observedTime < projectStartMoment ) {
+            return false;
+          }
+          // project d1 is time, observed is date
+          if ( !observedTime && observedDate ) {
+            const d1Offset = projectStartMoment.format( "Z" );
+            const comparableObservedDate = moment(
+              `${observedDate.format( "YYYY-MM-DD" )}T00:00:00${d1Offset}`
+            ).parseZone( );
+            if ( comparableObservedDate.startOf( "day" ) < projectStartMoment.startOf( "day" ) ) {
+              return false;
+            }
+          }
+        } else {
+          // project d1 is date, observed is time
+          if ( observedTime ) {
+            const observedOffset = observedTime.format( "Z" );
+            const comparableD1Date = moment(
+              `${projectStartMoment.format( "YYYY-MM-DD" )}T00:00:00${observedOffset}`
+            ).parseZone( );
+            if ( observedTime.startOf( "day" ) < comparableD1Date.startOf( "day" ) ) {
+              return false;
+            }
+          }
+          // project d1 is date, observed is date
+          if ( !observedTime && observedDate && observedDate < projectStartMoment.startOf( "day" ) ) {
+            return false;
+          }
+        }
+      }
+
+      if ( field === "d2" ) {
+        const projectEndMoment = moment( value ).parseZone( );
+        const projectEndIsDate = moment( value, "YYYY-MM-DD", true ).isValid( );
+        if ( !observedTime && !observedDate ) {
+          return false;
+        }
+        if ( !projectEndIsDate ) {
+          // project d2 is time, observed is time
+          if ( observedTime && observedTime > projectEndMoment ) {
+            return false;
+          }
+          // project d2 is time, observed is date
+          if ( !observedTime && observedDate ) {
+            const d2Offset = projectEndMoment.format( "Z" );
+            const comparableObservedDate = moment(
+              `${observedDate.format( "YYYY-MM-DD" )}T00:00:00${d2Offset}`
+            ).parseZone( );
+            if ( comparableObservedDate.startOf( "day" ) > projectEndMoment.startOf( "day" ) ) {
+              return false;
+            }
+          }
+        } else {
+          // project d2 is date, observed is time
+          if ( observedTime ) {
+            const observedOffset = observedTime.format( "Z" );
+            const comparableD2Date = moment(
+              `${projectEndMoment.format( "YYYY-MM-DD" )}T00:00:00${observedOffset}`
+            ).parseZone( );
+            if ( observedTime.startOf( "day" ) > comparableD2Date.startOf( "day" ) ) {
+              return false;
+            }
+          }
+          // project d2 is date, observed is date
+          if ( !observedTime && observedDate && observedDate > projectEndMoment.startOf( "day" ) ) {
+            return false;
+          }
+        }
+      }
+
+      if ( field === "observed_on" && observation.observed_on_details?.date !== value ) {
+        return false;
+      }
+      if ( field === "month" && !_.includes( value, observation.observed_on_details?.month ) ) {
+        return false;
+      }
+      if ( field === "members_only" && !_.includes( project.user_ids, observation.user?.id ) ) {
+        return false;
+      }
+      if ( field === "place_id" && _.isEmpty( _.intersection( observation.place_ids, value ) ) ) {
+        return false;
+      }
+      if ( field === "not_in_place" && !_.isEmpty( _.intersection( observation.place_ids, value ) ) ) {
+        return false;
+      }
+      if ( field === "taxon_id" && _.isEmpty( _.intersection( observation.taxon?.ancestor_ids, value ) ) ) {
+        return false;
+      }
+      if ( field === "without_taxon_id" && !_.isEmpty( _.intersection( observation.taxon?.ancestor_ids, value ) ) ) {
+        return false;
+      }
+      if ( field === "quality_grade" && !_.includes( value, observation.quality_grade ) ) {
+        return false;
+      }
+      if ( field === "photos" && ( _.isEmpty( observation.photos ) || observation.photos_count === 0 ) ) {
+        return false;
+      }
+      if ( field === "sounds" && ( _.isEmpty( observation.sounds ) || observation.sounds_count === 0 ) ) {
+        return false;
+      }
+      if ( field === "native" && !observation.taxon?.native ) {
+        return false;
+      }
+      if ( field === "introduced" && !observation.taxon?.introduced ) {
+        return false;
+      }
+      if ( field === "captive" && !observation.captive ) {
+        return false;
+      }
+      if ( field === "term_id" && !_.includes( _.map( observation.annotations, "controlled_attribute_id" ), value ) ) {
+        return false;
+      }
+      if ( field === "term_value_id" && !_.includes( _.map( observation.annotations, "controlled_value_id" ), value ) ) {
+        return false;
+      }
+      if ( field === "user_id" && !_.includes( value, observation.user?.id ) ) {
+        return false;
+      }
+      if ( field === "not_user_id" && _.includes( value, observation.user?.id ) ) {
+        return false;
+      }
+      return true;
+    } );
+  }
 };
 
 Project.modelName = "project";

--- a/schema/database.sql
+++ b/schema/database.sql
@@ -396,7 +396,17 @@ CREATE TABLE public.announcements (
     include_donor_start_date date,
     include_donor_end_date date,
     exclude_donor_start_date date,
-    exclude_donor_end_date date
+    exclude_donor_end_date date,
+    target_logged_in character varying DEFAULT 'any'::character varying,
+    min_identifications integer,
+    max_identifications integer,
+    min_observations integer,
+    max_observations integer,
+    user_created_start_date date,
+    user_created_end_date date,
+    last_observation_start_date date,
+    last_observation_end_date date,
+    ip_countries text[] DEFAULT '{}'::text[]
 );
 
 
@@ -2511,7 +2521,8 @@ CREATE TABLE public.messages (
     body text,
     read_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    sent_at timestamp without time zone
 );
 
 
@@ -4102,6 +4113,42 @@ ALTER SEQUENCE public.quality_metrics_id_seq OWNED BY public.quality_metrics.id;
 
 
 --
+-- Name: redirect_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.redirect_links (
+    id bigint NOT NULL,
+    user_id integer,
+    title character varying,
+    description text,
+    app_store_url character varying,
+    play_store_url character varying,
+    view_count integer DEFAULT 0,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: redirect_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.redirect_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: redirect_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.redirect_links_id_seq OWNED BY public.redirect_links.id;
+
+
+--
 -- Name: roles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4674,7 +4721,7 @@ ALTER SEQUENCE public.taggings_id_seq OWNED BY public.taggings.id;
 
 CREATE TABLE public.tags (
     id integer NOT NULL,
-    name character varying(255),
+    name character varying(255) COLLATE pg_catalog."und-x-icu",
     taggings_count integer DEFAULT 0
 );
 
@@ -5706,7 +5753,8 @@ CREATE TABLE public.users (
     data_transfer_consent_at timestamp without time zone,
     unconfirmed_email character varying,
     annotated_observations_count integer DEFAULT 0,
-    icon_path_version smallint DEFAULT 0 NOT NULL
+    icon_path_version smallint DEFAULT 0 NOT NULL,
+    canonical_email character varying(100)
 );
 
 
@@ -6610,6 +6658,13 @@ ALTER TABLE ONLY public.provider_authorizations ALTER COLUMN id SET DEFAULT next
 --
 
 ALTER TABLE ONLY public.quality_metrics ALTER COLUMN id SET DEFAULT nextval('public.quality_metrics_id_seq'::regclass);
+
+
+--
+-- Name: redirect_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.redirect_links ALTER COLUMN id SET DEFAULT nextval('public.redirect_links_id_seq'::regclass);
 
 
 --
@@ -7724,6 +7779,14 @@ ALTER TABLE ONLY public.quality_metrics
 
 
 --
+-- Name: redirect_links redirect_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.redirect_links
+    ADD CONSTRAINT redirect_links_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: roles roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8562,6 +8625,13 @@ CREATE INDEX index_deleted_observations_on_user_id_and_created_at ON public.dele
 --
 
 CREATE INDEX index_deleted_photos_on_created_at ON public.deleted_photos USING btree (created_at);
+
+
+--
+-- Name: index_deleted_photos_on_photo_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deleted_photos_on_photo_id ON public.deleted_photos USING btree (photo_id);
 
 
 --
@@ -9993,6 +10063,13 @@ CREATE INDEX index_quality_metrics_on_user_id ON public.quality_metrics USING bt
 
 
 --
+-- Name: index_redirect_links_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_redirect_links_on_user_id ON public.redirect_links USING btree (user_id);
+
+
+--
 -- Name: index_roles_users_on_role_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10606,6 +10683,13 @@ CREATE INDEX index_user_signups_on_ip_and_browser_id ON public.user_signups USIN
 --
 
 CREATE UNIQUE INDEX index_user_signups_on_user_id ON public.user_signups USING btree (user_id);
+
+
+--
+-- Name: index_users_on_canonical_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_canonical_email ON public.users USING btree (canonical_email);
 
 
 --
@@ -11395,8 +11479,22 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240828123245'),
 ('20240923134239'),
 ('20240923134658'),
+('20241016204033'),
 ('20241127180606'),
 ('20241202092831'),
+('20241217203007'),
 ('20241218164832'),
 ('20250124155306'),
-('20250127200519');
+('20250127200519'),
+('20250130003627'),
+('20250204222646'),
+('20250219234716'),
+('20250226225252'),
+('20250306224627'),
+('20250307000624'),
+('20250307004743'),
+('20250311191217'),
+('20250311212144'),
+('20250311225953');
+
+

--- a/test/models/project.js
+++ b/test/models/project.js
@@ -81,4 +81,536 @@ describe( "Project", ( ) => {
       expect( params.verifiable ).to.be.undefined;
     } );
   } );
+
+  describe( "collectionProjectRulesAllowObservation", ( ) => {
+    let observation;
+    let project;
+
+    const buildProject = ( parameters = {} ) => ( {
+      search_parameter_fields: parameters
+    } );
+
+    it( "d1 allows observed date to be equal", ( ) => {
+      project = buildProject( { d1: "2025-03-01" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d1 allows later observed dates", ( ) => {
+      project = buildProject( { d1: "2025-02-01" } );
+      observation = { observed_on: "2025-02-02" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d1 does not allow earlier observed dates", ( ) => {
+      project = buildProject( { d1: "2025-03-02" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d1 with times allows same or later dates", ( ) => {
+      project = buildProject( { d1: "2025-03-01T00:00:00Z" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d1: "2025-03-01T00:00:00-07:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d1: "2025-03-01T23:59:59+12:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: "2025-03-02" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d1: "2025-03-02T05:00:00-05:00" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-03-02T06:00:00-03:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-03-02T04:00:00-07:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d1 with times does not allow earlier dates", ( ) => {
+      project = buildProject( { d1: "2025-03-02T00:00:00Z" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      project = buildProject( { d1: "2025-03-02T00:00:00-07:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      project = buildProject( { d1: "2025-03-02T23:59:59+12:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { observed_on: "2025-03-03" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d1 requires an observed date", ( ) => {
+      project = buildProject( { d1: "2025-03-01" } );
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { observed_on: null };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d1 blank values are ignored", ( ) => {
+      project = buildProject( );
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: null };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: "2025-02-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d1 does not allow earlier observed time", ( ) => {
+      project = buildProject( { d1: "2025-02-01" } );
+      observation = { time_observed_at: "2025-01-31T23:59:59+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-01-31T23:59:59+12:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-01-31T23:59:59-05:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d1 allows exact and later observed times", ( ) => {
+      project = buildProject( { d1: "2025-02-01" } );
+      observation = { time_observed_at: "2025-02-01T00:00:00+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-02-01T01:00:00+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-02-01T01:00:00+12:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-02-01T00:00:00-05:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d2 allows observed date to be equal", ( ) => {
+      project = buildProject( { d2: "2025-03-01" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d2 allows ealier observed dates", ( ) => {
+      project = buildProject( { d2: "2025-03-02" } );
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d2 does not allow later observed dates", ( ) => {
+      project = buildProject( { d2: "2025-02-01" } );
+      observation = { observed_on: "2025-02-02" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d2 with times allows same or earlier dates", ( ) => {
+      project = buildProject( { d2: "2025-03-02T00:00:00Z" } );
+      observation = { observed_on: "2025-03-02" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d2: "2025-03-02T00:00:00-07:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d2: "2025-03-02T23:59:59+12:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      project = buildProject( { d2: "2025-03-02T05:00:00-05:00" } );
+      observation = { observed_on: "2025-03-03" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-03-02T06:00:00-03:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-03-02T04:00:00-07:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d2 with times does not allow later dates", ( ) => {
+      project = buildProject( { d2: "2025-03-02T00:00:00Z" } );
+      observation = { observed_on: "2025-03-03" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      project = buildProject( { d2: "2025-03-02T00:00:00-07:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      project = buildProject( { d2: "2025-03-02T23:59:59+12:00" } );
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { observed_on: "2025-03-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d2 requires an observed date", ( ) => {
+      project = buildProject( { d2: "2025-03-01" } );
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { observed_on: null };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d2 blank values are ignored", ( ) => {
+      project = buildProject( );
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: null };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on: "2025-02-01" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "d2 does not allow later observed times", ( ) => {
+      project = buildProject( { d2: "2025-02-01" } );
+      observation = { time_observed_at: "2025-02-02T00:00:00+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-02-02T00:00:00+12:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { time_observed_at: "2025-02-02T00:00:00-05:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "d2 allows exact and earlier observed times", ( ) => {
+      project = buildProject( { d2: "2025-02-01" } );
+      observation = { time_observed_at: "2025-02-01T00:00:00+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-01-31T23:59:59+00:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-02-01T23:59:59+12:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { time_observed_at: "2025-02-01T00:00:00-05:00" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "observed_on must match if present", ( ) => {
+      project = buildProject( { observed_on: "2025-02-01" } );
+      observation = { observed_on_details: { date: "2025-02-01" } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { observed_on_details: { date: "2025-03-01" } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "month must match if present", ( ) => {
+      project = buildProject( { month: [2, 3] } );
+      observation = { observed_on_details: { month: 2 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { observed_on_details: { month: 3 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { observed_on_details: { month: 4 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "members_only requires membership", ( ) => {
+      project = buildProject( { members_only: true } );
+      project.user_ids = [99, 100];
+      observation = { user: { id: 99 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { user: { id: 100 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { user: { id: 101 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      project.user_ids = [];
+      observation = { user: { id: 99 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "place_id requires place overlap", ( ) => {
+      project = buildProject( { place_id: [99, 100] } );
+      observation = { place_ids: [99, 100] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { place_ids: [98, 99] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { place_ids: [100, 101] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { place_ids: [101, 102] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { place_ids: [99] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { place_ids: [98] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "not_in_place disallows place overlap", ( ) => {
+      project = buildProject( { not_in_place: [99, 100] } );
+      observation = { place_ids: [99, 100] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { place_ids: [98, 99] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { place_ids: [100, 101] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { place_ids: [101, 102] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { place_ids: [99] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { place_ids: [98] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "taxon_id requires taxon overlap", ( ) => {
+      project = buildProject( { taxon_id: [99, 100] } );
+      observation = { taxon: { ancestor_ids: [99, 100] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { ancestor_ids: [98, 99] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { ancestor_ids: [100, 101] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { ancestor_ids: [101, 102] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { ancestor_ids: [99] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { ancestor_ids: [98] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "without_taxon_id disallows taxon overlap", ( ) => {
+      project = buildProject( { without_taxon_id: [99, 100] } );
+      observation = { taxon: { ancestor_ids: [99, 100] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { ancestor_ids: [98, 99] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { ancestor_ids: [100, 101] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { ancestor_ids: [101, 102] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { ancestor_ids: [99] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { ancestor_ids: [98] } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+
+    it( "quality_grade must match if present", ( ) => {
+      project = buildProject( { quality_grade: ["research", "verifiable"] } );
+      observation = { quality_grade: "research" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { quality_grade: "verifiable" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { quality_grade: "casual" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "photos requires photos to be present", ( ) => {
+      project = buildProject( { photos: true } );
+      observation = { photos_count: 1, photos: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { photos_count: 1, photos: [] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { photos_count: 0, photos: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { photos_count: 0 };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { sounds_count: 1, sounds: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "sounds requires sounds to be present", ( ) => {
+      project = buildProject( { sounds: true } );
+      observation = { sounds_count: 1, sounds: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { sounds_count: 1, sounds: [] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { sounds_count: 0, sounds: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { sounds_count: 0 };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { photos_count: 1, photos: [{ id: 1 }] };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "native requires taxon to be native", ( ) => {
+      project = buildProject( { native: true } );
+      observation = { taxon: { native: true } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { native: false } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "introduced requires taxon to be introduced", ( ) => {
+      project = buildProject( { introduced: true } );
+      observation = { taxon: { introduced: true } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { taxon: { introduced: false } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { taxon: { } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "captive requires observation to be captive", ( ) => {
+      project = buildProject( { captive: true } );
+      observation = { captive: true };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { captive: false };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "term_id requires annotation controlled_attribute_id overlap", ( ) => {
+      project = buildProject( { term_id: 99 } );
+      observation = {
+        annotations: [{
+          controlled_attribute_id: 99
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = {
+        annotations: [{
+          controlled_attribute_id: 100
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = {
+        annotations: [{
+          controlled_attribute_id: 99
+        }, {
+          controlled_attribute_id: 100
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = {
+        annotations: [{
+          controlled_attribute_id: 100
+        }, {
+          controlled_attribute_id: 101
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = {
+        annotations: [{
+          controlled_attribute_id: 101
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "term_value_id requires annotation controlled_value_id overlap", ( ) => {
+      project = buildProject( { term_value_id: 99 } );
+      observation = {
+        annotations: [{
+          controlled_value_id: 99
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = {
+        annotations: [{
+          controlled_value_id: 100
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = {
+        annotations: [{
+          controlled_value_id: 99
+        }, {
+          controlled_value_id: 100
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = {
+        annotations: [{
+          controlled_value_id: 100
+        }, {
+          controlled_value_id: 101
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = {
+        annotations: [{
+          controlled_value_id: 101
+        }]
+      };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "user_id must match if present", ( ) => {
+      project = buildProject( { user_id: [2, 3] } );
+      observation = { user: { id: 2 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { user: { id: 3 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { user: { id: 4 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+    } );
+
+    it( "not_user_id disallows matching user_ids", ( ) => {
+      project = buildProject( { not_user_id: [2, 3] } );
+      observation = { user: { id: 2 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { user: { id: 3 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { user: { id: 4 } };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
+  } );
 } );


### PR DESCRIPTION
Instead of creating complicated queries that will vary greatly from observation-to-observation, instead fetch all joined collection projects and filter them after fetching. This should take load off of Elasticsearch. For users that have joined many collection projects, this could potentially be a little slower, unless Elasticsearch is under heavy load in which case I suspect this approach will still be faster and use fewer total resources