### PR TITLE
refactor: set no_html to true when creating identifications

### DIFF
--- a/lib/controllers/v1/identifications_controller.js
+++ b/lib/controllers/v1/identifications_controller.js
@@ -12,6 +12,8 @@ const InaturalistAPI = require( "../../inaturalist_api" );
 
 const IdentificationsController = class IdentificationsController {
   static async create( req ) {
+    req.body ||= { };
+    req.body.no_html = true;
     const response = await InaturalistAPI.iNatJSWrap( identifications.create, req );
     const arr = [{ identification_id: response.id }];
     const localeOpts = util.localeOpts( req );


### PR DESCRIPTION
Set `no_html` to true in request bodies for identifications create requests. Without this, the rails controller is doing extra processing to include parts of the response that are ultimately not used