### PR TITLE
feat: add disagreements=true|false|any param to observations search

### DIFF
--- a/lib/models/observation_query_builder.js
+++ b/lib/models/observation_query_builder.js
@@ -723,6 +723,8 @@ ObservationQueryBuilder.reqToElasticQueryComponents = async req => {
     searchFilters.push( esClient.termFilter( "identifications_some_agree", true ) );
   } else if ( params.identifications === "most_disagree" ) {
     searchFilters.push( esClient.termFilter( "identifications_most_disagree", true ) );
+  } else if ( params.identifications === "some_disagree" ) {
+    searchFilters.push( { range: { num_identification_disagreements: { gt: 0 } } } );
   }
 
   if ( params.nelat || params.nelng || params.swlat || params.swlng ) {

--- a/lib/models/observation_query_builder.js
+++ b/lib/models/observation_query_builder.js
@@ -723,8 +723,6 @@ ObservationQueryBuilder.reqToElasticQueryComponents = async req => {
     searchFilters.push( esClient.termFilter( "identifications_some_agree", true ) );
   } else if ( params.identifications === "most_disagree" ) {
     searchFilters.push( esClient.termFilter( "identifications_most_disagree", true ) );
-  } else if ( params.identifications === "some_disagree" ) {
-    searchFilters.push( { range: { num_identification_disagreements: { gt: 0 } } } );
   }
 
   if ( params.nelat || params.nelng || params.swlat || params.swlng ) {

--- a/lib/models/observation_query_builder.js
+++ b/lib/models/observation_query_builder.js
@@ -725,6 +725,12 @@ ObservationQueryBuilder.reqToElasticQueryComponents = async req => {
     searchFilters.push( esClient.termFilter( "identifications_most_disagree", true ) );
   }
 
+  if ( params.disagreements === "true" ) {
+    searchFilters.push( { range: { identification_disagreements_count: { gt: 0 } } } );
+  } else if ( params.disagreements === "false" ) {
+    searchFilters.push( esClient.termFilter( "identification_disagreements_count", 0 ) );
+  }
+
   if ( params.nelat || params.nelng || params.swlat || params.swlng ) {
     searchFilters.push( {
       envelope: {

--- a/openapi/schema/request/observations_search.js
+++ b/openapi/schema/request/observations_search.js
@@ -275,6 +275,7 @@ module.exports = Joi.object( ).keys( {
       + "* **some_agree:** returns observations where there are some active identifications of taxa that agree with the Observation Taxon\n"
       + "* **most_disagree:** returns observations where there are more active identifications of taxa that disagree with the Observation Taxon than active identifications that agree with the Observation Taxon"
     ),
+  disagreements: Joi.boolean( ).description( "Whether there is disagreement among active identifications" ),
   lat: Joi.number( ).min( -90 ).max( 90 ),
   lng: Joi.number( ).min( -180 ).max( 180 ),
   radius: Joi.number( ).integer( ),

--- a/openapi/schema/request/observations_search.js
+++ b/openapi/schema/request/observations_search.js
@@ -267,15 +267,13 @@ module.exports = Joi.object( ).keys( {
     .valid(
       "most_agree",
       "most_disagree",
-      "some_agree",
-      "some_disagree"
+      "some_agree"
     )
     .description(
       "Filter by level of agreement among identifications:\n\n"
       + "* **most_agree:** returns observations where there are more active identifications of taxa that agree with the Observation Taxon than active identifications that disagree with the Observation Taxon\n"
       + "* **some_agree:** returns observations where there are some active identifications of taxa that agree with the Observation Taxon\n"
-      + "* **most_disagree:** returns observations where there are more active identifications of taxa that disagree with the Observation Taxon than active identifications that agree with the Observation Taxon\n"
-      + "* **some_disagree:** returns observations where there are some active identifications of taxa that disagree with the Observation Taxon"
+      + "* **most_disagree:** returns observations where there are more active identifications of taxa that disagree with the Observation Taxon than active identifications that agree with the Observation Taxon"
     ),
   lat: Joi.number( ).min( -90 ).max( 90 ),
   lng: Joi.number( ).min( -180 ).max( 180 ),

--- a/openapi/schema/request/observations_search.js
+++ b/openapi/schema/request/observations_search.js
@@ -262,11 +262,21 @@ module.exports = Joi.object( ).keys( {
   ) ),
   id_above: Joi.number( ).integer( ),
   id_below: Joi.number( ).integer( ),
-  identifications: Joi.string( ).valid(
-    "most_agree",
-    "most_disagree",
-    "some_agree"
-  ),
+  identifications: Joi
+    .string( )
+    .valid(
+      "most_agree",
+      "most_disagree",
+      "some_agree",
+      "some_disagree"
+    )
+    .description(
+      "Filter by level of agreement among identifications:\n\n"
+      + "* **most_agree:** returns observations where there are more active identifications of taxa that agree with the Observation Taxon than active identifications that disagree with the Observation Taxon\n"
+      + "* **some_agree:** returns observations where there are some active identifications of taxa that agree with the Observation Taxon\n"
+      + "* **most_disagree:** returns observations where there are more active identifications of taxa that disagree with the Observation Taxon than active identifications that agree with the Observation Taxon\n"
+      + "* **some_disagree:** returns observations where there are some active identifications of taxa that disagree with the Observation Taxon"
+    ),
   lat: Joi.number( ).min( -90 ).max( 90 ),
   lng: Joi.number( ).min( -180 ).max( 180 ),
   radius: Joi.number( ).integer( ),

--- a/test/controllers/v1/observations_controller.js
+++ b/test/controllers/v1/observations_controller.js
@@ -459,6 +459,11 @@ describe( "ObservationsController", ( ) => {
       expect( q.filters ).to.eql( [{ terms: { identifications_most_disagree: [true] } }] );
     } );
 
+    it( "filters by identifications some_disagree", async ( ) => {
+      const q = await Q( { identifications: "some_disagree" } );
+      expect( q.filters ).to.eql( [{ range: { num_identification_disagreements: { gt: 0 } } }] );
+    } );
+
     it( "filters by bounding box", async ( ) => {
       const q = await Q( {
         nelat: 1,

--- a/test/controllers/v1/observations_controller.js
+++ b/test/controllers/v1/observations_controller.js
@@ -459,11 +459,6 @@ describe( "ObservationsController", ( ) => {
       expect( q.filters ).to.eql( [{ terms: { identifications_most_disagree: [true] } }] );
     } );
 
-    it( "filters by identifications some_disagree", async ( ) => {
-      const q = await Q( { identifications: "some_disagree" } );
-      expect( q.filters ).to.eql( [{ range: { num_identification_disagreements: { gt: 0 } } }] );
-    } );
-
     it( "filters by bounding box", async ( ) => {
       const q = await Q( {
         nelat: 1,

--- a/test/controllers/v1/observations_controller.js
+++ b/test/controllers/v1/observations_controller.js
@@ -459,6 +459,21 @@ describe( "ObservationsController", ( ) => {
       expect( q.filters ).to.eql( [{ terms: { identifications_most_disagree: [true] } }] );
     } );
 
+    it( "filters by disagreements=true", async ( ) => {
+      const q = await Q( { disagreements: "true" } );
+      expect( q.filters ).to.eql( [{ range: { identification_disagreements_count: { gt: 0 } } }] );
+    } );
+
+    it( "filters by disagreements=false", async ( ) => {
+      const q = await Q( { disagreements: "false" } );
+      expect( q.filters ).to.eql( [{ term: { identification_disagreements_count: 0 } }] );
+    } );
+
+    it( "filters by disagreements=any", async ( ) => {
+      const q = await Q( { disagreements: "any" } );
+      expect( q.filters ).to.eql( [] );
+    } );
+
     it( "filters by bounding box", async ( ) => {
       const q = await Q( {
         nelat: 1,


### PR DESCRIPTION
Supports WEB-508 by adding support for disagreements=true|false|any to the observations search endpoints. Also expands the docs for this parameter and others.