### PR TITLE
fix: allow updating profile pic when faved projects chosen

### DIFF
--- a/openapi/openapi_util.js
+++ b/openapi/openapi_util.js
@@ -11,6 +11,15 @@ const openapiUtil = class openapiUtil {
           openapiUtil.applicationJsonToMultipart( attr.schema, thisKey )
         );
       } else {
+        // Note that array values will get appended here and may not actually
+        // validate properly, b/c if there is an attribute like
+        // user.some_array, it will get declared here as user
+        // [some_array], but when submitted as a multipart request, each
+        // value will be user[some_array][0] (or another index), and openapi
+        // raise an error due to an unknown key. We are currently handling
+        // that by allowing unknown attributes in multipart requests that
+        // support array values, with the caveat that these values will not
+        // be properly validated.
         multipartRequest = multipartRequest.append( { [thisKey]: attr.schema } );
       }
     } );

--- a/openapi/schema/request/users_update_multipart.js
+++ b/openapi/schema/request/users_update_multipart.js
@@ -2,6 +2,10 @@ const Joi = require( "joi" );
 const usersUpdate = require( "./users_update" );
 const openapiUtil = require( "../../openapi_util" );
 
-module.exports = openapiUtil.applicationJsonToMultipart( usersUpdate ).append( {
-  "user[icon]": Joi.binary( )
-} );
+// Convert the JSON schema to equivalent FormData keys, e.g. user[description]
+module.exports = openapiUtil.applicationJsonToMultipart( usersUpdate )
+  .append( { "user[icon]": Joi.binary( ) } )
+  // Unfortunately, array items will be submitted in FormData as
+  // user[some_array_attr][0], and we don't know of a way to specify
+  // wildcards in keys
+  .unknown( true );


### PR DESCRIPTION
Allows unknown attributes in multipart PUT /v2/users/:id requests. This allows this endpoint to receive multipart attributes like users[faved_project_ids] [0] even though we don't specify that as an allowed attribute. The root of the problem is converting a Joi schema that expects a JSON array to one that expects multipart FormData. There may be a better way to do this using Joi's pattern() option.

Closes WEB-716