### PR TITLE
Fix copy-paste error ("photo" should be "sounds")

### DIFF
--- a/openapi/schema/response/results_observation_sounds.js
+++ b/openapi/schema/response/results_observation_sounds.js
@@ -1,9 +1,9 @@
 const Joi = require( "joi" );
-const observationPhoto = require( "./observation_photo" );
+const observationSound = require( "./observation_sound" );
 
 module.exports = Joi.object( ).keys( {
   total_results: Joi.number( ).integer( ).required( ),
   page: Joi.number( ).integer( ).required( ),
   per_page: Joi.number( ).integer( ).required( ),
-  results: Joi.array( ).items( observationPhoto ).required( )
+  results: Joi.array( ).items( observationSound ).required( )
 } ).unknown( false );


### PR DESCRIPTION
While developing github.com/Sajmani/inat and github.com/Sajmani/birdsync, I encountered an error decoding the result for ObservationSounds. I tracked down the issue to this copy-paste error in the model. I have not run any tests on this though.