### PR TITLE
Return the original filename for observation photos or sounds

### DIFF
--- a/lib/models/observation.js
+++ b/lib/models/observation.js
@@ -292,9 +292,9 @@ const Observation = class Observation extends Model {
     await Promise.all( [
       TaxaController.assignAncestors( { }, taxa, { localeOpts, ancestors: true } ),
       ESModel.fetchBelongsTo( withUsers, User, { } ),
-      ObservationPreload.observationSounds( obs ),
+      ObservationPreload.observationSounds( obs, localeOpts ),
       ObservationPreload.userPreferences( obs ),
-      ObservationPreload.observationPhotos( obs )
+      ObservationPreload.observationPhotos( obs, localeOpts )
     ] );
     if ( req.inat && req.inat.isV2 && req.inat.fieldRequested( "application" ) ) {
       await ObservationPreload.applications( obs );

--- a/lib/models/observation_preload.js
+++ b/lib/models/observation_preload.js
@@ -141,7 +141,7 @@ const ObservationPreload = class ObservationPreload {
     } );
   }
 
-  static async observationPhotos( obs ) {
+  static async observationPhotos( obs, options = { } ) {
     if ( obs.length === 0 ) { return; }
     const obsIDs = _.map( obs, "id" );
     if ( _.isEmpty( obsIDs ) ) { return; }
@@ -165,7 +165,8 @@ const ObservationPreload = class ObservationPreload {
       };
     } );
     // lookup and assign photo objects to each observationPhoto
-    await ObservationPreload.assignObservationPhotoPhotos( observationPhotos );
+    const loggedInUserID = options && options.userSession ? options.userSession.user_id : null;
+    await ObservationPreload.assignObservationPhotoPhotos( observationPhotos, loggedInUserID );
     _.each( obs, o => {
       const unsortedObsObsPhotos = _.filter( observationPhotos, op => op.observation_id === o.id );
       o.observation_photos = _.sortBy( unsortedObsObsPhotos, ["position", "id"] );
@@ -180,7 +181,7 @@ const ObservationPreload = class ObservationPreload {
     } );
   }
 
-  static async assignObservationPhotoPhotos( observationPhotos ) {
+  static async assignObservationPhotoPhotos( observationPhotos, loggedInUserID ) {
     const photoIDs = _.flatten( _.uniq( _.map( _.flatten( _.values( observationPhotos ) ), "photo_id" ) ) );
     if ( photoIDs.length === 0 ) { return; }
     const photos = { };
@@ -212,9 +213,11 @@ const ObservationPreload = class ObservationPreload {
         original_dimensions: {
           width: r.width,
           height: r.height
-        },
-        file_file_name: r.file_file_name
+        }
       };
+      if ( loggedInUserID && r.user_id === loggedInUserID ) {
+        photo.file_file_name = r.file_file_name;
+      }
       if ( r.prefix ) {
         photo.url = util.fixHttps( `${r.prefix}/${photo.id}/square.${r.extension}` );
       }
@@ -322,7 +325,7 @@ const ObservationPreload = class ObservationPreload {
     } );
   }
 
-  static async observationSounds( obs ) {
+  static async observationSounds( obs, options = { } ) {
     if ( obs.length === 0 ) { return; }
     const obsIDs = _.map( obs, "id" );
     if ( _.isEmpty( obsIDs ) ) { return; }
@@ -352,24 +355,31 @@ const ObservationPreload = class ObservationPreload {
         o.observation_sounds = _.sortBy( obsSounds[o.id], ["id"] );
       }
     } );
-    await ObservationPreload.assignSoundFilenames( sounds );
+    const loggedInUserID = options && options.userSession ? options.userSession.user_id : null;
+    await ObservationPreload.assignSoundFilenames( sounds, loggedInUserID );
     await ObservationPreload.assignSoundFlags( sounds );
     await ObservationPreload.assignSoundModeratorActions( sounds );
   }
 
-  static async assignSoundFilenames( sounds ) {
+  static async assignSoundFilenames( sounds, loggedInUserID ) {
     const soundIDs = _.map( sounds, "id" );
     if ( soundIDs.length === 0 ) { return; }
-    const query = squel.select( ).fields( ["id", "file_file_name"] )
+    const query = squel.select( ).fields( ["id", "file_file_name", "user_id"] )
       .from( "sounds" )
       .where( "id IN ?", soundIDs );
     const { rows } = await pgClient.replica.query( query.toString( ) );
-    const soundFilenames = { };
+    const soundInfo = { };
     _.each( rows, r => {
-      soundFilenames[r.id] = r.file_file_name;
+      soundInfo[r.id] = {
+        file_file_name: r.file_file_name,
+        user_id: r.user_id
+      };
     } );
     _.each( sounds, s => {
-      s.file_file_name = soundFilenames[s.id];
+      delete s.file_file_name;
+      if ( soundInfo[s.id] && loggedInUserID && loggedInUserID === soundInfo[s.id].user_id ) {
+        s.file_file_name = soundInfo[s.id].file_file_name;
+      }
     } );
   }
 

--- a/lib/models/observation_preload.js
+++ b/lib/models/observation_preload.js
@@ -192,6 +192,7 @@ const ObservationPreload = class ObservationPreload {
       .field( "photos.native_username" )
       .field( "photos.width" )
       .field( "photos.height" )
+      .field( "photos.file_file_name" )
       .field( "file_prefixes.prefix" )
       .field( "file_extensions.extension" )
       .from( "photos" )
@@ -211,7 +212,8 @@ const ObservationPreload = class ObservationPreload {
         original_dimensions: {
           width: r.width,
           height: r.height
-        }
+        },
+        file_file_name: r.file_file_name
       };
       if ( r.prefix ) {
         photo.url = util.fixHttps( `${r.prefix}/${photo.id}/square.${r.extension}` );
@@ -350,8 +352,25 @@ const ObservationPreload = class ObservationPreload {
         o.observation_sounds = _.sortBy( obsSounds[o.id], ["id"] );
       }
     } );
+    await ObservationPreload.assignSoundFilenames( sounds );
     await ObservationPreload.assignSoundFlags( sounds );
     await ObservationPreload.assignSoundModeratorActions( sounds );
+  }
+
+  static async assignSoundFilenames( sounds ) {
+    const soundIDs = _.map( sounds, "id" );
+    if ( soundIDs.length === 0 ) { return; }
+    const query = squel.select( ).fields( ["id", "file_file_name"] )
+      .from( "sounds" )
+      .where( "id IN ?", soundIDs );
+    const { rows } = await pgClient.replica.query( query.toString( ) );
+    const soundFilenames = { };
+    _.each( rows, r => {
+      soundFilenames[r.id] = r.file_file_name;
+    } );
+    _.each( sounds, s => {
+      s.file_file_name = soundFilenames[s.id];
+    } );
   }
 
   static async assignSoundModeratorActions( sounds ) {

--- a/lib/models/observation_preload.js
+++ b/lib/models/observation_preload.js
@@ -165,7 +165,7 @@ const ObservationPreload = class ObservationPreload {
       };
     } );
     // lookup and assign photo objects to each observationPhoto
-    const loggedInUserID = options && options.userSession ? options.userSession.user_id : null;
+    const loggedInUserID = options?.userSession?.user_id;
     await ObservationPreload.assignObservationPhotoPhotos( observationPhotos, loggedInUserID );
     _.each( obs, o => {
       const unsortedObsObsPhotos = _.filter( observationPhotos, op => op.observation_id === o.id );
@@ -181,7 +181,7 @@ const ObservationPreload = class ObservationPreload {
     } );
   }
 
-  static async assignObservationPhotoPhotos( observationPhotos, loggedInUserID ) {
+  static async assignObservationPhotoPhotos( observationPhotos, loggedInUserID = null ) {
     const photoIDs = _.flatten( _.uniq( _.map( _.flatten( _.values( observationPhotos ) ), "photo_id" ) ) );
     if ( photoIDs.length === 0 ) { return; }
     const photos = { };
@@ -216,7 +216,7 @@ const ObservationPreload = class ObservationPreload {
         }
       };
       if ( loggedInUserID && r.user_id === loggedInUserID ) {
-        photo.file_file_name = r.file_file_name;
+        photo.original_filename = r.file_file_name;
       }
       if ( r.prefix ) {
         photo.url = util.fixHttps( `${r.prefix}/${photo.id}/square.${r.extension}` );
@@ -355,13 +355,14 @@ const ObservationPreload = class ObservationPreload {
         o.observation_sounds = _.sortBy( obsSounds[o.id], ["id"] );
       }
     } );
-    const loggedInUserID = options && options.userSession ? options.userSession.user_id : null;
+    const loggedInUserID = options?.userSession?.user_id;
     await ObservationPreload.assignSoundFilenames( sounds, loggedInUserID );
     await ObservationPreload.assignSoundFlags( sounds );
     await ObservationPreload.assignSoundModeratorActions( sounds );
   }
 
-  static async assignSoundFilenames( sounds, loggedInUserID ) {
+  static async assignSoundFilenames( sounds, loggedInUserID = null ) {
+    if ( !loggedInUserID ) { return; }
     const soundIDs = _.map( sounds, "id" );
     if ( soundIDs.length === 0 ) { return; }
     const query = squel.select( ).fields( ["id", "file_file_name", "user_id"] )
@@ -376,9 +377,9 @@ const ObservationPreload = class ObservationPreload {
       };
     } );
     _.each( sounds, s => {
-      delete s.file_file_name;
+      delete s.original_filename;
       if ( soundInfo[s.id] && loggedInUserID && loggedInUserID === soundInfo[s.id].user_id ) {
-        s.file_file_name = soundInfo[s.id].file_file_name;
+        s.original_filename = soundInfo[s.id].file_file_name;
       }
     } );
   }

--- a/openapi/schema/response/photo.js
+++ b/openapi/schema/response/photo.js
@@ -24,6 +24,7 @@ module.exports = Joi.object( ).keys( {
   small_url: Joi.string( ).valid( null ),
   square_url: Joi.string( ).valid( null ),
   type: Joi.string( ),
-  url: Joi.string( ).valid( null )
+  url: Joi.string( ).valid( null ),
+  file_file_name: Joi.string( ).valid( null )
 } ).unknown( false ).meta( { className: "Photo" } )
   .valid( null );

--- a/openapi/schema/response/photo.js
+++ b/openapi/schema/response/photo.js
@@ -25,6 +25,6 @@ module.exports = Joi.object( ).keys( {
   square_url: Joi.string( ).valid( null ),
   type: Joi.string( ),
   url: Joi.string( ).valid( null ),
-  file_file_name: Joi.string( ).valid( null )
+  original_filename: Joi.string( ).valid( null )
 } ).unknown( false ).meta( { className: "Photo" } )
   .valid( null );

--- a/openapi/schema/response/sound.js
+++ b/openapi/schema/response/sound.js
@@ -11,6 +11,7 @@ module.exports = Joi.object( ).keys( {
   id: Joi.number( ).integer( ).description( "Unique auto-increment integer identifier." ).required( ),
   license_code: Joi.string( ).valid( null ),
   moderator_actions: Joi.array( ).items( moderatorAction ),
-  native_sound_id: Joi.string( ).valid( null )
+  native_sound_id: Joi.string( ).valid( null ),
+  file_file_name: Joi.string( ).valid( null )
 } ).unknown( false ).meta( { className: "Sound" } )
   .valid( null );

--- a/openapi/schema/response/sound.js
+++ b/openapi/schema/response/sound.js
@@ -12,6 +12,6 @@ module.exports = Joi.object( ).keys( {
   license_code: Joi.string( ).valid( null ),
   moderator_actions: Joi.array( ).items( moderatorAction ),
   native_sound_id: Joi.string( ).valid( null ),
-  file_file_name: Joi.string( ).valid( null )
+  original_filename: Joi.string( ).valid( null )
 } ).unknown( false ).meta( { className: "Sound" } )
   .valid( null );

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -1193,10 +1193,17 @@
           "photo_licenses": ["cc-by"],
           "photos_count": 1,
           "description": "Observation with media with moderator actions with no users",
+          "photos": [
+            {
+              "id": 2025012201,
+              "user_id": 123
+            }
+          ],
           "sounds": [
             {
               "id": 2025012201,
-              "license_code": "CC-BY"
+              "license_code": "CC-BY",
+              "user_id": 123
             }
           ],
           "sounds_count": 1

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -445,7 +445,11 @@ describe( "Observations", ( ) => {
     it( "should return original filenames for photos and sounds", function ( done ) {
       const o2 = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 2025012201 );
+      const token = jwt.sign( { user_id: 123 },
+        config.jwtSecret || "secret",
+        { algorithm: "HS512" } );
       request( this.app ).get( `/v2/observations/${o2.uuid}?fields=all` )
+        .set( "Authorization", token )
         .expect( res => {
           const observation = res.body.results[0];
           expect( observation.photos[0].file_file_name ).to.not.be.undefined;

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -443,8 +443,9 @@ describe( "Observations", ( ) => {
     } );
 
     it( "should return original filenames for photos and sounds", function ( done ) {
-      const obs = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
-      request( this.app ).get( `/v2/observations/${obs.uuid}?fields=all` )
+      const o2 = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 2025012201 );
+      request( this.app ).get( `/v2/observations/${o2.uuid}?fields=all` )
         .expect( res => {
           const observation = res.body.results[0];
           expect( observation.photos[0].file_file_name ).to.not.be.undefined;

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -442,6 +442,17 @@ describe( "Observations", ( ) => {
         .expect( 200, done );
     } );
 
+    it( "should return original filenames for photos and sounds", function ( done ) {
+      const obs = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      request( this.app ).get( `/v2/observations/${obs.uuid}?fields=all` )
+        .expect( res => {
+          const observation = res.body.results[0];
+          expect( observation.photos[0].file_file_name ).to.not.be.undefined;
+          expect( observation.sounds[0].file_file_name ).to.not.be.undefined;
+        } )
+        .expect( 200, done );
+    } );
+
     it( "should error with internal server error as result window is too large for elastic search", function ( done ) {
       request( this.app )
         .get( "/v2/observations?page=700" )

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -454,8 +454,8 @@ describe( "Observations", ( ) => {
         .set( "Authorization", token )
         .expect( res => {
           const observation = res.body.results[0];
-          expect( observation.photos[0].file_file_name ).to.not.be.undefined;
-          expect( observation.sounds[0].file_file_name ).to.not.be.undefined;
+          expect( observation.photos[0].original_filename ).to.not.be.undefined;
+          expect( observation.sounds[0].original_filename ).to.not.be.undefined;
         } )
         .expect( 200, done );
     } );

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -445,6 +445,8 @@ describe( "Observations", ( ) => {
     it( "should return original filenames for photos and sounds", function ( done ) {
       const o2 = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 2025012201 );
+      // Simulate the user logged in with ID 123, which matches the user_id for
+      // this observation's photos and sounds in fixtures.js.
       const token = jwt.sign( { user_id: 123 },
         config.jwtSecret || "secret",
         { algorithm: "HS512" } );

--- a/test/models/observation_preload.js
+++ b/test/models/observation_preload.js
@@ -36,7 +36,8 @@ describe( "ObservationPreload", ( ) => {
     } );
 
     it( "fills file_file_name when logged in as photo owner", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 29 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 5 } };
       await ObservationPreload.observationPhotos( obs, options );
@@ -44,7 +45,8 @@ describe( "ObservationPreload", ( ) => {
     } );
 
     it( "does not fill file_file_name when logged in as another user", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 29 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 1 } };
       await ObservationPreload.observationPhotos( obs, options );
@@ -52,7 +54,8 @@ describe( "ObservationPreload", ( ) => {
     } );
 
     it( "does not fill file_file_name when not logged in", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 29 );
       const obs = [new Observation( observation )];
       await ObservationPreload.observationPhotos( obs, { } );
       expect( obs[0].photos[0].file_file_name ).to.be.undefined;
@@ -61,7 +64,8 @@ describe( "ObservationPreload", ( ) => {
 
   describe( "observationSounds", ( ) => {
     it( "fills file_file_name when logged in as sound owner", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 123 } };
       await ObservationPreload.observationSounds( obs, options );
@@ -69,7 +73,8 @@ describe( "ObservationPreload", ( ) => {
     } );
 
     it( "does not fill file_file_name when logged in as another user", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 1 } };
       await ObservationPreload.observationSounds( obs, options );
@@ -77,7 +82,8 @@ describe( "ObservationPreload", ( ) => {
     } );
 
     it( "does not fill file_file_name when not logged in", async ( ) => {
-      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       await ObservationPreload.observationSounds( obs, { } );
       expect( obs[0].sounds[0].file_file_name ).to.be.undefined;

--- a/test/models/observation_preload.js
+++ b/test/models/observation_preload.js
@@ -35,58 +35,58 @@ describe( "ObservationPreload", ( ) => {
       expect( obs[0].observation_photos[0].photo.attribution ).to.match( /some rights reserved \(CC BY\)/ );
     } );
 
-    it( "fills file_file_name when logged in as photo owner", async ( ) => {
+    it( "fills original_filename when logged in as photo owner", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 29 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 5 } };
       await ObservationPreload.observationPhotos( obs, options );
-      expect( obs[0].photos[0].file_file_name ).to.not.be.undefined;
+      expect( obs[0].photos[0].original_filename ).to.not.be.undefined;
     } );
 
-    it( "does not fill file_file_name when logged in as another user", async ( ) => {
+    it( "does not fill original_filename when logged in as another user", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 29 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 1 } };
       await ObservationPreload.observationPhotos( obs, options );
-      expect( obs[0].photos[0].file_file_name ).to.be.undefined;
+      expect( obs[0].photos[0].original_filename ).to.be.undefined;
     } );
 
-    it( "does not fill file_file_name when not logged in", async ( ) => {
+    it( "does not fill original_filename when not logged in", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 29 );
       const obs = [new Observation( observation )];
       await ObservationPreload.observationPhotos( obs, { } );
-      expect( obs[0].photos[0].file_file_name ).to.be.undefined;
+      expect( obs[0].photos[0].original_filename ).to.be.undefined;
     } );
   } );
 
   describe( "observationSounds", ( ) => {
-    it( "fills file_file_name when logged in as sound owner", async ( ) => {
+    it( "fills original_filename when logged in as sound owner", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 123 } };
       await ObservationPreload.observationSounds( obs, options );
-      expect( obs[0].sounds[0].file_file_name ).to.not.be.undefined;
+      expect( obs[0].sounds[0].original_filename ).to.not.be.undefined;
     } );
 
-    it( "does not fill file_file_name when logged in as another user", async ( ) => {
+    it( "does not fill original_filename when logged in as another user", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       const options = { userSession: { user_id: 1 } };
       await ObservationPreload.observationSounds( obs, options );
-      expect( obs[0].sounds[0].file_file_name ).to.be.undefined;
+      expect( obs[0].sounds[0].original_filename ).to.be.undefined;
     } );
 
-    it( "does not fill file_file_name when not logged in", async ( ) => {
+    it( "does not fill original_filename when not logged in", async ( ) => {
       const observation = _.find( fixtures.elasticsearch.observations.observation,
         o => o.id === 2025012201 );
       const obs = [new Observation( observation )];
       await ObservationPreload.observationSounds( obs, { } );
-      expect( obs[0].sounds[0].file_file_name ).to.be.undefined;
+      expect( obs[0].sounds[0].original_filename ).to.be.undefined;
     } );
   } );
 } );

--- a/test/models/observation_preload.js
+++ b/test/models/observation_preload.js
@@ -34,5 +34,53 @@ describe( "ObservationPreload", ( ) => {
       expect( obs[0].observation_photos[0].photo.license_code ).to.eq( "cc-by" );
       expect( obs[0].observation_photos[0].photo.attribution ).to.match( /some rights reserved \(CC BY\)/ );
     } );
+
+    it( "fills file_file_name when logged in as photo owner", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const obs = [new Observation( observation )];
+      const options = { userSession: { user_id: 5 } };
+      await ObservationPreload.observationPhotos( obs, options );
+      expect( obs[0].photos[0].file_file_name ).to.not.be.undefined;
+    } );
+
+    it( "does not fill file_file_name when logged in as another user", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const obs = [new Observation( observation )];
+      const options = { userSession: { user_id: 1 } };
+      await ObservationPreload.observationPhotos( obs, options );
+      expect( obs[0].photos[0].file_file_name ).to.be.undefined;
+    } );
+
+    it( "does not fill file_file_name when not logged in", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 29 );
+      const obs = [new Observation( observation )];
+      await ObservationPreload.observationPhotos( obs, { } );
+      expect( obs[0].photos[0].file_file_name ).to.be.undefined;
+    } );
+  } );
+
+  describe( "observationSounds", ( ) => {
+    it( "fills file_file_name when logged in as sound owner", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const obs = [new Observation( observation )];
+      const options = { userSession: { user_id: 123 } };
+      await ObservationPreload.observationSounds( obs, options );
+      expect( obs[0].sounds[0].file_file_name ).to.not.be.undefined;
+    } );
+
+    it( "does not fill file_file_name when logged in as another user", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const obs = [new Observation( observation )];
+      const options = { userSession: { user_id: 1 } };
+      await ObservationPreload.observationSounds( obs, options );
+      expect( obs[0].sounds[0].file_file_name ).to.be.undefined;
+    } );
+
+    it( "does not fill file_file_name when not logged in", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation, o => o.id === 2025012201 );
+      const obs = [new Observation( observation )];
+      await ObservationPreload.observationSounds( obs, { } );
+      expect( obs[0].sounds[0].file_file_name ).to.be.undefined;
+    } );
   } );
 } );


### PR DESCRIPTION
This enables tools like github.com/Sajmani/birdsync to detect which assets have already been uploaded by matching the original filename on iNaturalist against that of the source asset.

Added a test; everything appears to be passing:
```
...
      ✔ should return original filenames for photos and sounds
...
  1025 passing (14s)


=============================== Coverage summary ===============================
Statements   : 83.91% ( 8334/9932 )
Branches     : 72.98% ( 3613/4950 )
Functions    : 81.23% ( 1238/1524 )
Lines        : 84.68% ( 8140/9612 )
================================================================================
```