### PR TITLE
docs: describe GET /v1/observations response more completely

### DIFF
--- a/lib/views/swagger_v1.yml.ejs
+++ b/lib/views/swagger_v1.yml.ejs
@@ -701,6 +701,8 @@ paths:
         - $ref: "#/parameters/path_multi_id"
       tags:
         - Observations
+      security:
+        - api_key: []
       responses:
         200:
           description: |
@@ -933,6 +935,8 @@ paths:
         <%- include( "_observation_search_params_v1.yml.ejs", { type: "index" } ) %>
       tags:
         - Observations
+      security:
+        - api_token: []
       responses:
         200:
           description: |
@@ -3502,6 +3506,27 @@ securityDefinitions:
     name: Authorization
     in: header
 definitions:
+  Annotation:
+    type: object
+    properties:
+      uuid:
+        type: string
+      controlled_attribute_id:
+        type: integer
+      controlled_value_id:
+        type: integer
+      concatenated_attr_val:
+        type: string
+      user:
+        $ref: "#/definitions/User"
+      user_id:
+        type: integer
+      vote_score:
+        type: integer
+      votes:
+        type: array
+        items:
+          $ref: "#/definitions/Vote"
   AutocompleteTaxon:
     allOf:
       - $ref: "#/definitions/CoreTaxon"
@@ -3964,6 +3989,10 @@ definitions:
   Observation:
     type: object
     properties:
+      annotations:
+        type: array
+        items:
+          $ref: "#/definitions/Annotation"
       id:
         type: integer
       cached_votes_total:
@@ -4045,6 +4074,10 @@ definitions:
         type: array
         items:
           type: integer
+      positional_accuracy:
+        type: integer
+      private_geojson:
+        $ref: "#/definitions/PointGeoJson"
       project_ids:
         type: array
         items:
@@ -4057,6 +4090,8 @@ definitions:
         type: array
         items:
           type: integer
+      public_positional_accuracy:
+        type: integer
       quality_grade:
         type: string
       reviewed_by:
@@ -4089,8 +4124,136 @@ definitions:
         type: string
       user:
         $ref: "#/definitions/User"
+      uuid:
+        type: string
       verifiable:
         type: boolean
+      observation_photos:
+        type: array
+        items:
+          $ref: "#/definitions/ObservationPhoto"
+      quality_metrics:
+        type: array
+        items:
+          $ref: "#/definitions/QualityMetric"
+      flags:
+        type: array
+        items:
+          $ref: "#/definitions/Flag"
+      community_taxon_id:
+        type: integer
+      faves:
+        type: array
+        items:
+          $ref: "#/definitions/Fave"
+      identifications:
+        type: array
+        items:
+          $ref: "#/definitions/Identification"
+      oauth_application_id:
+        type: integer
+      outlinks:
+        type: array
+        items:
+          $ref: "#/definitions/Outlink"
+      owners_identification_from_vision:
+        type: boolean
+      preferences:
+        type: object
+      project_observations:
+        type: array
+        items:
+          $ref: "#/definitions/ProjectObservation"
+      spam:
+        type: boolean
+      votes:
+        type: array
+        items:
+          $ref: "#/definitions/Vote"
+      identification_disagreements_count:
+        type: integer
+      ident_taxon_ids:
+        type: array
+        items:
+          type: integer
+      map_scale:
+        type: integer
+  ObservationPhoto:
+    type: object
+    properties:
+      id:
+        type: integer
+      uuid:
+        type: string
+      photo:
+        $ref: "#/definitions/Photo"
+      position:
+        type: integer
+  QualityMetric:
+    type: object
+    properties:
+      id:
+        type: integer
+      user_id:
+        type: integer
+      metric:
+        type: string
+      agree:
+        type: boolean
+  Flag:
+    type: object
+    properties:
+      id:
+        type: integer
+      flag:
+        type: string
+      comment:
+        type: string
+      resolved:
+        type: boolean
+      user:
+        $ref: "#/definitions/User"
+      created_at:
+        type: string
+        format: date-time
+  Outlink:
+    type: object
+    properties:
+      id:
+        type: integer
+      source:
+        type: string
+      url:
+        type: string
+  ProjectObservation:
+    type: object
+    properties:
+      id:
+        type: integer
+      project_id:
+        type: integer
+      observation_id:
+        type: integer
+      curator_identification_id:
+        type: integer
+      tracking_code:
+        type: string
+      prefers_curator_coordinate_access:
+        type: boolean
+  Vote:
+    type: object
+    properties:
+      id:
+        type: integer
+      user_id:
+        type: integer
+      vote_flag:
+        type: boolean
+      vote_scope:
+        type: string
+      created_at:
+        type: string
+        format: date-time
   ObservationTaxon:
     allOf:
       - $ref: "#/definitions/CoreTaxon"


### PR DESCRIPTION
Also document support for auth.

This helps support the creation of client libraries based on the Swagger description of the API.