### PR TITLE
feat: adds photo_id param for computer vision scoreObservation

### DIFF
--- a/lib/controllers/v1/computervision_controller.js
+++ b/lib/controllers/v1/computervision_controller.js
@@ -57,6 +57,9 @@ const ComputervisionController = class ComputervisionController {
     if ( !req.userSession && !req.applicationSession ) {
       throw util.httpError( 401, "Unauthorized" );
     }
+    if ( req.query.photo_id && Number.isNaN( req.query.photo_id ) ) {
+      throw util.httpError( 422, "photo_id is not a number" );
+    }
     const obsID = Number( req.params.id );
     if ( !obsID ) {
       throw util.httpError( 422, "Missing observation ID or UUID" );
@@ -79,14 +82,17 @@ const ComputervisionController = class ComputervisionController {
     let photoURL;
     _.each( observation.photos, p => {
       if ( photoURL ) { return; }
+      if ( req.query.photo_id && p.id !== Number( req.query.photo_id ) ) { return; }
       if ( !p.url ) { return; }
       photoURL = p.url;
       if ( photoURL.match( /\/square\./i ) ) {
         photoURL = p.url.replace( "/square.", "/medium." );
       }
     } );
-    if ( !photoURL ) {
+    if ( !photoURL && !req.query.photo_id ) {
       throw util.httpError( 422, "Observation has no scorable photos" );
+    } else if ( !photoURL ) {
+      throw util.httpError( 422, "Observation has no scorable photos or no photo with the provided id" );
     }
     req.query.image_url = photoURL;
     return ComputervisionController.scoreImageURL( req, { observation } );

--- a/openapi/paths/v2/computervision/score_observation/{uuid}.js
+++ b/openapi/paths/v2/computervision/score_observation/{uuid}.js
@@ -25,6 +25,12 @@ module.exports = sendWrapper => {
           .description( "A single observation UUID" )
       ),
       transform(
+        Joi.number( ).integer( )
+          .label( "photo_id" )
+          .meta( { in: "query" } )
+          .description( "The photo id associated with the observation to use for suggestions." )
+      ),
+      transform(
         Joi.string( ).label( "fields" ).meta( { in: "query" } )
           .description( `
 Fields are the fields of the nested taxon object in the results, so to specify

--- a/test/integration/v2/computervision.js
+++ b/test/integration/v2/computervision.js
@@ -89,6 +89,30 @@ describe( "Computervision", ( ) => {
         .set( "Authorization", token )
         .expect( 401, done );
     } );
+    it( "filters for photo id if provided", function ( done ) {
+      const token = jwt.sign(
+        { application: "whatever" },
+        config.jwtApplicationSecret || "application_secret",
+        { algorithm: "HS512" }
+      );
+      request( this.app ).get( `${url}?photo_id=1` )
+        .set( "Authorization", token )
+        .expect( 200 )
+        .expect( res => {
+          expect( res.body.results.length ).to.be.above( 0 );
+        } )
+        .expect( 200, done );
+    } );
+    it( "should fail when given a photo id not attributed to the observation", function ( done ) {
+      const token = jwt.sign(
+        { application: "whatever" },
+        config.jwtApplicationSecret || "application_secret",
+        { algorithm: "HS512" }
+      );
+      request( this.app ).get( `${url}?photo_id=2020101601` )
+        .set( "Authorization", token )
+        .expect( 422, done );
+    } );
   } );
   describe( "score_image", ( ) => {
     const token = jwt.sign(


### PR DESCRIPTION
# Objective

Give the user the ability to select which photo under an observation will be sent to the computer vision model, see https://forum.inaturalist.org/t/use-computer-vision-on-each-photo-in-an-observation/4210 , it had one very recent comment about it. The objective is NOT to allow using multiple photos to get some type of combined score, but just the ability to select ONE photo from the observation.

## Solution

This extends the API to accept an additional query parameter, `photo_id`, that will be used to get the specific observation photo to pass on to the computer vision model. If the `photo_id` provided is not associated with the observation, the request returns a 422.

If this gets merged, I intend to follow up with a pull-request in `inaturalist` to take the selected photo’s id (keeping in mind flagged photos I guess!) in obs/show and use it to pass on to `TaxonAutocomplete` as a part of `visionParams` prop.

## Testing

I extended the existing integration test in the v2 section to test calling the endpoint with the new param (there is already an existing test without the `photo_id` param). I ran computervision specific tests and they were fine.

## Alternatives considered

I did think about just switching the api call in `inaturalist` to use the `score_image` endpoint, and adding the additional context manually (like lat, long, observed_on… this seems to be what the observation uploader does [Is this what iNat next is doing too?]), but it looks like the score_image endpoint accepts image bytes, and it does not make sense to me to constantly send the image bytes over the api, especially if people might be switching between the photos to check for different cv suggestions. It makes more sense to me to just reference the photo by id and have the server handle photo fetching / context setting in this case.
 
If iNat expects to support multiple photos to get a combined score in the near term, I do question if this new query param might make things tougher for that but I suppose that’s up for discussion in this PR. Perhaps that will just be a new endpoint if ever implemented!