### PR TITLE
Correct typo in util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -691,7 +691,7 @@ util.iucnValues = {
   ne: 0,
   dd: 5,
   lc: 10,
-  ny: 20,
+  nt: 20,
   vu: 30,
   en: 40,
   cr: 50,


### PR DESCRIPTION
Near threatened was coded as `ny` rather than `nt`