### PR TITLE
feat: add filter to exclude observations casual for reasons other than captive, related to WEB-912

### DIFF
--- a/lib/models/observation.js
+++ b/lib/models/observation.js
@@ -36,6 +36,7 @@ const Observation = class Observation extends Model {
     delete this.sounds_count;
     delete this.geo_score;
     delete this.dqa_stats;
+    delete this.quality_grade_if_not_captive;
   }
 
   makeBackwardsCompatible( ) {

--- a/lib/models/observation_query_builder.js
+++ b/lib/models/observation_query_builder.js
@@ -746,6 +746,28 @@ ObservationQueryBuilder.reqToElasticQueryComponents = async req => {
       ) );
     }
   }
+
+  if ( params.not_casual_excluding_captive ) {
+    // exclude observations that have quality_grade=casual and either do not have a value for
+    // `quality_grade_if_not_captive`, or the value is `casual`. i.e. - casual observations can
+    // be included, but only if they are casual for reasons other than being marked captive
+    inverseFilters.push( {
+      bool: {
+        must: [
+          esClient.termFilter( "quality_grade", "casual" ),
+          {
+            bool: {
+              should: [
+                esClient.termFilter( "quality_grade_if_not_captive", "casual" ),
+                { bool: { must_not: { exists: { field: "quality_grade_if_not_captive" } } } }
+              ]
+            }
+          }
+        ]
+      }
+    } );
+  }
+
   if ( params.identifications === "most_agree" ) {
     searchFilters.push( esClient.termFilter( "identifications_most_agree", true ) );
   } else if ( params.identifications === "some_agree" ) {

--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -399,6 +399,17 @@ const Project = class Project extends Model {
       if ( field === "not_user_id" && _.includes( value, observation.user?.id ) ) {
         return false;
       }
+      // if the project allows `not_casual_excluding_captive` - ensure there are no observations
+      // that are casual where `quality_grade_if_not_captive` is not set, or is set to casual
+      if ( field === "not_casual_excluding_captive"
+        && observation.quality_grade === "casual"
+        && (
+          !observation.quality_grade_if_not_captive
+          || observation.quality_grade_if_not_captive === "casual"
+        )
+      ) {
+        return false;
+      }
       return true;
     } );
   }

--- a/openapi/schema/request/observations_search.js
+++ b/openapi/schema/request/observations_search.js
@@ -368,6 +368,8 @@ module.exports = Joi.object( ).keys( {
     "needs_id",
     "research"
   ) ).description( "Include observations with this quality grade" ),
+  not_casual_excluding_captive: Joi.boolean( )
+    .description( "Exclude observations that are casual for any reason other than being marked captive" ),
   without_field: Joi.string( )
     .description( "Exclude observations with this observation field" ),
   outlink_source: Joi.string( )

--- a/test/controllers/v1/observations_controller.js
+++ b/test/controllers/v1/observations_controller.js
@@ -479,6 +479,25 @@ describe( "ObservationsController", ( ) => {
         { terms: { quality_grade: ["casual"] } }] );
     } );
 
+    it( "filters by not_casual_excluding_captive", async ( ) => {
+      const q = await Q( { not_casual_excluding_captive: "true" } );
+      expect( q.inverse_filters ).to.eql( [{
+        bool: {
+          must: [
+            { terms: { quality_grade: ["casual"] } },
+            {
+              bool: {
+                should: [
+                  { terms: { quality_grade_if_not_captive: ["casual"] } },
+                  { bool: { must_not: { exists: { field: "quality_grade_if_not_captive" } } } }
+                ]
+              }
+            }
+          ]
+        }
+      }] );
+    } );
+
     it( "filters by identifications most_agree", async ( ) => {
       const q = await Q( { identifications: "most_agree" } );
       expect( q.filters ).to.eql( [{ terms: { identifications_most_agree: [true] } }] );

--- a/test/models/project.js
+++ b/test/models/project.js
@@ -625,5 +625,20 @@ describe( "Project", ( ) => {
       observation = { };
       expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
     } );
+
+    it( "not_casual_excluding_captive disallows non-captive casuals", ( ) => {
+      project = buildProject( { not_casual_excluding_captive: true } );
+      observation = { quality_grade: "casual" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { quality_grade: "casual", quality_grade_if_not_captive: "casual" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.false;
+      observation = { quality_grade: "casual", quality_grade_if_not_captive: "needs_id" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+      observation = { quality_grade: "research" };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+
+      observation = { };
+      expect( Project.collectionProjectRulesAllowObservation( project, observation ) ).to.be.true;
+    } );
   } );
 } );


### PR DESCRIPTION
Add observation search parameter `not_casual_excluding_captive` which excludes observations that have quality_grade=casual and either do not have a value for `quality_grade_if_not_captive`, or the value is `casual`. i.e. - casual observations can be included, but only if they are casual because they were marked captive