### PR TITLE
feat(WEB-1059): add v2 iconic_taxa_counts endpoint

### DIFF
--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -965,18 +965,30 @@ ObservationsController.taxonomy = async req => {
   };
 };
 
-ObservationsController.iconicTaxaCounts = async req => {
+ObservationsController.iconicTaxaCounts = async ( req, options = { } ) => {
   const countQuery = _.assignIn( { }, req.query );
+  const iconicTaxaTerms = {
+    field: "taxon.iconic_taxon_id",
+    size: 100
+  };
+  if ( options.includeUnknown ) {
+    // bucket observations without an iconic taxon, e.g. observations without
+    // an identification or of taxa outside all iconic taxa, under a sentinel
+    // key of 0, matching what the `iconic_taxa=unknown` filter would return
+    iconicTaxaTerms.missing = 0;
+  }
   countQuery.aggs = {
     iconic_taxa: {
-      terms: { field: "taxon.iconic_taxon_id" }
+      terms: iconicTaxaTerms
     }
   };
   countQuery.per_page = 0;
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const buckets = _.map( data.aggregations.iconic_taxa.buckets, b => (
-    { taxon_id: b.key, count: b.doc_count }
+    b.key === 0
+      ? { taxon_id: null, count: b.doc_count, taxon: null }
+      : { taxon_id: b.key, count: b.doc_count }
   ) );
   const localeOpts = util.localeOpts( req );
   const prepareTaxon = t => {
@@ -1000,7 +1012,7 @@ ObservationsController.iconicTaxaSpeciesCounts = async req => {
     per_page: 0,
     aggs: {
       iconic_taxa: {
-        terms: { field: "taxon.iconic_taxon_id" },
+        terms: { field: "taxon.iconic_taxon_id", size: 100 },
         aggs: {
           ancestries: { terms: { field: "taxon.min_species_ancestry", size: 300000 } }
         }

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -986,7 +986,7 @@ ObservationsController.iconicTaxaCounts = async ( req, options = { } ) => {
   const countReq = _.assignIn( { }, req, { query: countQuery } );
   const data = await ObservationsController.elasticResults( countReq );
   const buckets = _.map( data.aggregations.iconic_taxa.buckets, b => (
-    b.key === 0
+    Number( b.key ) === 0
       ? { taxon_id: null, count: b.doc_count, taxon: null }
       : { taxon_id: b.key, count: b.doc_count }
   ) );

--- a/lib/controllers/v1/observations_controller.js
+++ b/lib/controllers/v1/observations_controller.js
@@ -972,9 +972,6 @@ ObservationsController.iconicTaxaCounts = async ( req, options = { } ) => {
     size: 100
   };
   if ( options.includeUnknown ) {
-    // bucket observations without an iconic taxon, e.g. observations without
-    // an identification or of taxa outside all iconic taxa, under a sentinel
-    // key of 0, matching what the `iconic_taxa=unknown` filter would return
     iconicTaxaTerms.missing = 0;
   }
   countQuery.aggs = {

--- a/lib/controllers/v2/observations_controller.js
+++ b/lib/controllers/v2/observations_controller.js
@@ -194,6 +194,7 @@ module.exports = {
   deleteQualityMetric,
   fave,
   histogram: ctrlv1.histogramCacheWrapper,
+  iconicTaxaCounts: req => ctrlv1.iconicTaxaCounts( req, { includeUnknown: true } ),
   iconicTaxaSpeciesCounts: ctrlv1.iconicTaxaSpeciesCounts,
   identificationCategories: ctrlv1.identificationCategories,
   identifiers: ctrlv1.identifiersCacheWrapper,

--- a/openapi/paths/v2/observations/iconic_taxa_counts.js
+++ b/openapi/paths/v2/observations/iconic_taxa_counts.js
@@ -1,0 +1,49 @@
+const _ = require( "lodash" );
+const Joi = require( "joi" );
+const transform = require( "../../../joi_to_openapi_parameter" );
+const ObservationsController = require( "../../../../lib/controllers/v2/observations_controller" );
+const observationsSearchSchema = require( "../../../schema/request/observations_search" );
+
+module.exports = sendWrapper => {
+  async function GET( req, res ) {
+    const results = await ObservationsController.iconicTaxaCounts( req );
+    sendWrapper( req, res, null, results );
+  }
+
+  const parameters = _.map(
+    observationsSearchSchema.$_terms.keys,
+    child => transform( child.schema.label( child.key ) )
+  );
+  parameters.push(
+    transform( Joi.string( ).label( "X-HTTP-Method-Override" ).meta( { in: "header" } ) )
+  );
+
+  GET.apiDoc = {
+    tags: ["Observations"],
+    summary: "Fetch observation counts by iconic taxon",
+    description: "Given zero to many of same parameters as the observation search API, "
+      + "returns observation counts grouped by iconic taxon. Results include an entry "
+      + "with a null taxon counting observations without an iconic taxon, equivalent to "
+      + "filtering observations with `iconic_taxa=unknown`",
+    security: [{
+      userJwtOptional: []
+    }],
+    parameters,
+    responses: {
+      200: {
+        description: "An array of observation counts by iconic taxon.",
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ResultsObservationsIconicTaxaCounts"
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return {
+    GET
+  };
+};

--- a/openapi/schema/response/results_observations_iconic_taxa_counts.js
+++ b/openapi/schema/response/results_observations_iconic_taxa_counts.js
@@ -1,0 +1,12 @@
+const Joi = require( "joi" );
+const taxon = require( "./taxon" );
+
+module.exports = Joi.object( ).keys( {
+  total_results: Joi.number( ).integer( ).required( ),
+  page: Joi.number( ).integer( ).required( ),
+  per_page: Joi.number( ).integer( ).required( ),
+  results: Joi.array( ).items( Joi.object( ).keys( {
+    count: Joi.number( ).integer( ).required( ),
+    taxon: taxon.valid( null ).required( )
+  } ).unknown( false ) ).required( )
+} ).unknown( false );

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -8,6 +8,8 @@ const jwt = require( "jsonwebtoken" );
 const sinon = require( "sinon" );
 const config = require( "../../../config" );
 const esClient = require( "../../../lib/es_client" );
+const ESModel = require( "../../../lib/models/es_model" );
+const Taxon = require( "../../../lib/models/taxon" );
 
 const fixtures = JSON.parse( fs.readFileSync( "schema/fixtures.js" ) );
 
@@ -1465,6 +1467,9 @@ describe( "Observations", ( ) => {
   } );
 
   describe( "iconic_taxa_counts", ( ) => {
+    const sandbox = sinon.createSandbox( );
+    afterEach( ( ) => sandbox.restore( ) );
+
     it( "returns observation counts by iconic taxon sorted by count", function ( done ) {
       request( this.app ).get( "/v1/observations/iconic_taxa_counts" ).expect( res => {
         expect( res.body.results ).to.not.be.empty;
@@ -1478,12 +1483,44 @@ describe( "Observations", ( ) => {
       } ).expect( "Content-Type", /json/ )
         .expect( 200, done );
     } );
+
+    it( "requests enough aggregation buckets for all iconic taxa", function ( done ) {
+      sandbox.spy( ESModel, "elasticResults" );
+      request( this.app ).get( "/v1/observations/iconic_taxa_counts" ).expect( ( ) => {
+        const call = _.find( ESModel.elasticResults.getCalls( ), c => (
+          c.args[0].query && c.args[0].query.aggs && c.args[0].query.aggs.iconic_taxa
+        ) );
+        expect( call ).to.not.be.undefined;
+        const iconicTaxaTerms = call.args[0].query.aggs.iconic_taxa.terms;
+        expect( iconicTaxaTerms.field ).to.eq( "taxon.iconic_taxon_id" );
+        expect( iconicTaxaTerms.size ).to.be.at.least( Taxon.ICONIC_TAXON_NAMES.length + 1 );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
   } );
 
   describe( "iconic_taxa_species_counts", ( ) => {
+    const sandbox = sinon.createSandbox( );
+    afterEach( ( ) => sandbox.restore( ) );
+
     it( "returns json", function ( done ) {
       request( this.app ).get( "/v1/observations/iconic_taxa_species_counts" )
         .expect( "Content-Type", /json/ ).expect( 200, done );
+    } );
+
+    it( "requests enough aggregation buckets for all iconic taxa", function ( done ) {
+      sandbox.spy( ESModel, "elasticResults" );
+      request( this.app ).get( "/v1/observations/iconic_taxa_species_counts" ).expect( ( ) => {
+        const call = _.find( ESModel.elasticResults.getCalls( ), c => (
+          c.args[0].query && c.args[0].query.aggs && c.args[0].query.aggs.iconic_taxa
+        ) );
+        expect( call ).to.not.be.undefined;
+        const iconicTaxaAgg = call.args[0].query.aggs.iconic_taxa;
+        expect( iconicTaxaAgg.terms.field ).to.eq( "taxon.iconic_taxon_id" );
+        expect( iconicTaxaAgg.terms.size ).to.be.at.least( Taxon.ICONIC_TAXON_NAMES.length + 1 );
+        expect( iconicTaxaAgg.aggs.ancestries ).to.not.be.undefined;
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
     } );
   } );
 

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -1475,7 +1475,8 @@ describe( "Observations", ( ) => {
         } );
         const counts = _.map( res.body.results, "count" );
         expect( counts ).to.eql( _.clone( counts ).sort( ( a, b ) => b - a ) );
-      } ).expect( "Content-Type", /json/ ).expect( 200, done );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
     } );
   } );
 

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -1465,9 +1465,17 @@ describe( "Observations", ( ) => {
   } );
 
   describe( "iconic_taxa_counts", ( ) => {
-    it( "returns json", function ( done ) {
-      request( this.app ).get( "/v1/observations/iconic_taxa_counts" )
-        .expect( "Content-Type", /json/ ).expect( 200, done );
+    it( "returns observation counts by iconic taxon sorted by count", function ( done ) {
+      request( this.app ).get( "/v1/observations/iconic_taxa_counts" ).expect( res => {
+        expect( res.body.results ).to.not.be.empty;
+        _.each( res.body.results, r => {
+          expect( r.taxon_id ).to.be.a( "number" );
+          expect( r.count ).to.be.above( 0 );
+          expect( r.taxon ).to.not.be.undefined;
+        } );
+        const counts = _.map( res.body.results, "count" );
+        expect( counts ).to.eql( _.clone( counts ).sort( ( a, b ) => b - a ) );
+      } ).expect( "Content-Type", /json/ ).expect( 200, done );
     } );
   } );
 

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -1054,6 +1054,35 @@ describe( "Observations", ( ) => {
     } );
   } );
 
+  describe( "iconicTaxaCounts", ( ) => {
+    it( "returns counts by iconic taxon including an unknown bucket", function ( done ) {
+      request( this.app ).get( "/v2/observations/iconic_taxa_counts?fields=all" ).expect( res => {
+        expect( res.body.results ).to.not.be.empty;
+        const counts = _.map( res.body.results, "count" );
+        expect( counts ).to.eql( _.clone( counts ).sort( ( a, b ) => b - a ) );
+        const unknown = _.filter( res.body.results, r => r.taxon === null );
+        expect( unknown.length ).to.eq( 1 );
+        expect( unknown[0].count ).to.be.above( 0 );
+        const known = _.reject( res.body.results, r => r.taxon === null );
+        expect( known ).to.not.be.empty;
+        _.each( known, r => {
+          expect( r.count ).to.be.above( 0 );
+          expect( r.taxon.id ).to.be.a( "number" );
+        } );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+
+    it( "returns count and taxon by default", function ( done ) {
+      request( this.app ).get( "/v2/observations/iconic_taxa_counts" ).expect( res => {
+        const withTaxon = _.find( res.body.results, r => r.taxon );
+        expect( withTaxon.count ).to.be.above( 0 );
+        expect( withTaxon.taxon.id ).to.be.a( "number" );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+  } );
+
   describe( "observers", ( ) => {
     it( "returns json", function ( done ) {
       request( this.app ).get( "/v2/observations/observers?user_id=1" ).expect( res => {

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -10,6 +10,7 @@ const config = require( "../../../config" );
 const ESModel = require( "../../../lib/models/es_model" );
 const esClient = require( "../../../lib/es_client" );
 const ObservationsController = require( "../../../lib/controllers/v1/observations_controller" );
+const Taxon = require( "../../../lib/models/taxon" );
 
 const fixtures = JSON.parse( fs.readFileSync( "schema/fixtures.js" ) );
 let obs;
@@ -1055,6 +1056,24 @@ describe( "Observations", ( ) => {
   } );
 
   describe( "iconicTaxaCounts", ( ) => {
+    const sandbox = sinon.createSandbox( );
+    afterEach( ( ) => sandbox.restore( ) );
+
+    it( "requests enough aggregation buckets for all iconic taxa plus unknown", function ( done ) {
+      sandbox.spy( ESModel, "elasticResults" );
+      request( this.app ).get( "/v2/observations/iconic_taxa_counts" ).expect( ( ) => {
+        const call = _.find( ESModel.elasticResults.getCalls( ), c => (
+          c.args[0].query && c.args[0].query.aggs && c.args[0].query.aggs.iconic_taxa
+        ) );
+        expect( call ).to.not.be.undefined;
+        const iconicTaxaTerms = call.args[0].query.aggs.iconic_taxa.terms;
+        expect( iconicTaxaTerms.field ).to.eq( "taxon.iconic_taxon_id" );
+        expect( iconicTaxaTerms.size ).to.be.at.least( Taxon.ICONIC_TAXON_NAMES.length + 1 );
+        expect( iconicTaxaTerms.missing ).to.eq( 0 );
+      } ).expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+
     it( "returns counts by iconic taxon including an unknown bucket", function ( done ) {
       request( this.app ).get( "/v2/observations/iconic_taxa_counts?fields=all" ).expect( res => {
         expect( res.body.results ).to.not.be.empty;


### PR DESCRIPTION
Adds a category to the iconic_taxa_counts endpoint response for unknown taxa. This is identified by a result in the results list where `taxon` is `null`.

```
results [ 
    {
        "count": 2198,
        "taxon": null
    },
    ...
]
```

https://github.com/inaturalist/inaturalistjs/pull/110 adds better handling of the Unknown Taxon in inaturalistjs.