### PR TITLE
fix: users v2 following and followed_by, WEB-1071

### DIFF
--- a/lib/controllers/v2/users_controller.js
+++ b/lib/controllers/v2/users_controller.js
@@ -1,4 +1,5 @@
 const _ = require( "lodash" );
+const squel = require( "safe-squel" );
 const { users } = require( "inaturalistjs" );
 const config = require( "../../../config" );
 const pgClient = require( "../../pg_client" );
@@ -62,9 +63,14 @@ const index = async req => {
     if ( !followingUser ) {
       throw httpError( 422, `User ${req.query.following} does not exist` );
     }
-    const { rows: followers } = await pgClient.replica.query(
-      `SELECT user_id FROM friendships WHERE friend_id = ${followingUser.id}`
-    );
+    const followersQuery = squel.select( )
+      .field( "friendships.user_id" )
+      .from( "friendships" )
+      .join( "users", null, "friendships.user_id = users.id" )
+      .where( "friendships.friend_id = ?", followingUser.id )
+      .where( "friendships.following = ?", true )
+      .where( "users.suspended_at IS NULL" );
+    const { rows: followers } = await pgClient.replica.query( followersQuery.toString( ) );
     filters.push( esClient.termFilter( "id", _.map( followers, f => f.user_id ) ) );
   }
   if ( req.query.followed_by ) {
@@ -72,9 +78,14 @@ const index = async req => {
     if ( !followedByUser ) {
       throw httpError( 422, `User ${req.query.followed_by} does not exist` );
     }
-    const { rows: followees } = await pgClient.replica.query(
-      `SELECT friend_id FROM friendships WHERE user_id = ${followedByUser.id}`
-    );
+    const followeesQuery = squel.select( )
+      .field( "friendships.friend_id" )
+      .from( "friendships" )
+      .join( "users", null, "friendships.friend_id = users.id" )
+      .where( "friendships.user_id = ?", followedByUser.id )
+      .where( "friendships.following = ?", true )
+      .where( "users.suspended_at IS NULL" );
+    const { rows: followees } = await pgClient.replica.query( followeesQuery.toString( ) );
     filters.push( esClient.termFilter( "id", _.map( followees, f => f.friend_id ) ) );
   }
   if ( req.query.orcid ) {

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -2437,6 +2437,7 @@
         "user_id": 126,
         "friend_id": 125,
         "trust": true,
+        "following": true,
         "created_at": "2021-10-08 01:00:00",
         "updated_at": "2021-10-08 01:00:00"
       },
@@ -2445,6 +2446,7 @@
         "user_id": 127,
         "friend_id": 123,
         "trust": true,
+        "following": true,
         "created_at": "2021-10-08 01:00:00",
         "updated_at": "2021-10-08 01:00:00"
       },
@@ -2481,6 +2483,22 @@
         "friend_id": 126,
         "trust": false,
         "following": true,
+        "created_at": "2021-10-08 01:00:00",
+        "updated_at": "2021-10-08 01:00:00"
+      },
+      {
+        "id": 7,
+        "user_id": 127,
+        "friend_id": 125,
+        "following": false,
+        "created_at": "2021-10-08 01:00:00",
+        "updated_at": "2021-10-08 01:00:00"
+      },
+      {
+        "id": 8,
+        "user_id": 126,
+        "friend_id": 127,
+        "following": false,
         "created_at": "2021-10-08 01:00:00",
         "updated_at": "2021-10-08 01:00:00"
       }

--- a/test/integration/v2/users.js
+++ b/test/integration/v2/users.js
@@ -165,50 +165,47 @@ describe( "Users", ( ) => {
         } )
         .expect( 200, done );
     } );
+
     it( "should filter by following", function ( done ) {
-      const friendship = fixtures.postgresql.friendships[0];
-      const followingUserId = friendship.user_id;
-      const followingUserIds = _.filter(
-        fixtures.postgresql.friendships,
-        f => f.friend_id === friendship.friend_id
-      ).map( f => f.user_id );
-      const notFollowingUserId = _.find(
-        fixtures.postgresql.users,
-        u => ( followingUserIds.indexOf( u.id ) < 0 )
-      ).id;
-      request( this.app ).get( `/v2/users?per_page=100&following=${friendship.friend_id}` )
+      const firstFriendship = fixtures.postgresql.friendships[0];
+      const inverseFriendships = _.filter( fixtures.postgresql.friendships, f => (
+        f.friend_id === firstFriendship.friend_id
+      ) );
+      const followers = _.map( _.filter( inverseFriendships, f => (
+        !!f.following
+      ) ), "user_id" );
+      expect( _.size( inverseFriendships ) ).to.be.above( _.size( followers ) );
+
+      request( this.app ).get( `/v2/users?per_page=100&following=${firstFriendship.friend_id}` )
         .expect( 200 )
         .expect( res => {
           expect( res.body.results ).not.to.be.empty;
-          expect(
-            _.find( res.body.results, u => u.id === followingUserId )
-          ).not.to.be.undefined;
-          expect(
-            _.find( res.body.results, u => u.id === notFollowingUserId )
-          ).to.be.undefined;
+          expect( res.body.total_results ).to.eq( _.size( followers ) );
+          expect( _.sortBy( _.map( res.body.results, "id" ) ) ).to.deep.eq(
+            _.sortBy( followers )
+          );
         } )
         .expect( 200, done );
     } );
+
     it( "should filter by followed_by", function ( done ) {
-      const friendship = fixtures.postgresql.friendships[0];
-      const friendIds = _.filter(
-        fixtures.postgresql.friendships,
-        f => f.user_id === friendship.user_id
-      );
-      const notFollowedByUserId = _.find(
-        fixtures.postgresql.users,
-        u => friendIds.indexOf( u.id ) < 0
-      ).id;
-      request( this.app ).get( `/v2/users?per_page=100&followed_by=${friendship.user_id}` )
+      const firstFriendship = fixtures.postgresql.friendships[0];
+      const friendships = _.filter( fixtures.postgresql.friendships, f => (
+        f.user_id === firstFriendship.user_id
+      ) );
+      const followees = _.map( _.filter( friendships, f => (
+        !!f.following
+      ) ), "friend_id" );
+      expect( _.size( friendships ) ).to.be.above( _.size( followees ) );
+
+      request( this.app ).get( `/v2/users?per_page=100&followed_by=${firstFriendship.user_id}` )
         .expect( 200 )
         .expect( res => {
           expect( res.body.results ).not.to.be.empty;
-          expect(
-            _.find( res.body.results, u => u.id === friendship.friend_id )
-          ).not.to.be.undefined;
-          expect(
-            _.find( res.body.results, u => u.id === notFollowedByUserId )
-          ).to.be.undefined;
+          expect( res.body.total_results ).to.eq( _.size( followees ) );
+          expect( _.sortBy( _.map( res.body.results, "id" ) ) ).to.deep.eq(
+            _.sortBy( followees )
+          );
         } )
         .expect( 200, done );
     } );


### PR DESCRIPTION
Ensure we only look at rows where `friendship = 't'` and where the relevant user is not suspended when searching followers or followees