### PR TITLE
specs(web-931): regression specs for missing photo records

### DIFF
--- a/lib/logstasher.js
+++ b/lib/logstasher.js
@@ -188,6 +188,19 @@ const Logstasher = class Logstasher {
     }
   }
 
+  static writeMissingMediaLog( mediaType, observationId, mediaId, joinRecordId ) {
+    if ( !Logstasher.logWriteStream( ) ) { return; }
+    const payload = {
+      "@timestamp": new Date( ).toISOString( ),
+      subtype: "MissingMedia",
+      media_type: mediaType,
+      observation_id: observationId,
+      media_id: mediaId,
+      join_record_id: joinRecordId
+    };
+    Logstasher.logWriteStream( ).write( `${JSON.stringify( payload )}\n` );
+  }
+
   static writeAnnouncementImpressionLog( req, announcementID ) {
     if ( !req || !announcementID ) {
       return;

--- a/lib/models/observation_preload.js
+++ b/lib/models/observation_preload.js
@@ -5,6 +5,7 @@ const pgClient = require( "../pg_client" );
 const util = require( "../util" );
 const ESModel = require( "./es_model" );
 const Identification = require( "./identification" );
+const Logstasher = require( "../logstasher" );
 const User = require( "./user" );
 const config = require( "../../config" );
 
@@ -232,7 +233,10 @@ const ObservationPreload = class ObservationPreload {
     await ObservationPreload.assignPhotoModeratorActions( photos );
     // assign photo objects to each observationPhoto
     _.each( observationPhotos, op => {
-      op.photo = photos[op.photo_id];
+      op.photo = photos[op.photo_id] || null;
+      if ( !op.photo ) {
+        Logstasher.writeMissingMediaLog( "photo", op.observation_id, op.photo_id, op.id );
+      }
     } );
   }
 
@@ -347,7 +351,10 @@ const ObservationPreload = class ObservationPreload {
     const obsSounds = { };
     _.each( result.rows, r => {
       obsSounds[r.observation_id] = obsSounds[r.observation_id] || [];
-      const sound = _.find( sounds, s => s.id === r.sound_id );
+      const sound = _.find( sounds, s => s.id === r.sound_id ) || null;
+      if ( !sound ) {
+        Logstasher.writeMissingMediaLog( "sound", r.observation_id, r.sound_id, r.id );
+      }
       obsSounds[r.observation_id].push( {
         id: r.id,
         uuid: r.uuid,

--- a/schema/fixtures.js
+++ b/schema/fixtures.js
@@ -1366,6 +1366,22 @@
           "sounds_count": 1
         },
         {
+          "id": 2026071301,
+          "uuid": "3f2ab1de-9f24-46a1-a1ce-9429a4bb43a1",
+          "user": { "id": 123 },
+          "description": "Observation with observation_photos and observation_sounds referencing deleted media",
+          "photo_licenses": ["cc-by"],
+          "photos_count": 1,
+          "sounds": [
+            {
+              "id": 2026071301,
+              "license_code": "CC-BY",
+              "user_id": 123
+            }
+          ],
+          "sounds_count": 1
+        },
+        {
           "id": 4321,
           "uuid": "dc568fef-2030-4079-9661-88a5f5e30bc2",
           "user": { "id": 123 },
@@ -2950,6 +2966,10 @@
       {
         "id": 2025012202,
         "uuid": "537d9290-df3c-404f-a26d-ffe07156908c"
+      },
+      {
+        "id": 2026071301,
+        "uuid": "3f2ab1de-9f24-46a1-a1ce-9429a4bb43a1"
       }
     ],
     "observation_photos": [
@@ -2997,6 +3017,24 @@
         "created_at": "2025-01-22 01:00:00",
         "updated_at": "2025-01-22 01:00:00",
         "uuid": "ad529a09-97df-4daa-bc88-8eff4881d872"
+      },
+      {
+        "id": 2026071301,
+        "observation_id": 2026071301,
+        "photo_id": 2026071399,
+        "position": 0,
+        "created_at": "2026-07-13 01:00:00",
+        "updated_at": "2026-07-13 01:00:00",
+        "uuid": "0d4a3f9b-53b1-4a55-90a1-6d92cf8f21f1"
+      },
+      {
+        "id": 2026071302,
+        "observation_id": 2026071301,
+        "photo_id": 2026071301,
+        "position": 1,
+        "created_at": "2026-07-13 01:00:00",
+        "updated_at": "2026-07-13 01:00:00",
+        "uuid": "6cf0a97b-e5e4-4f43-8bb1-8a17b8e6cdb2"
       }
     ],
     "observation_sounds": [
@@ -3015,6 +3053,22 @@
         "created_at": "2025-01-22 01:00:00",
         "updated_at": "2025-01-22 01:00:00",
         "uuid": "5eef64b4-7ca6-49c1-abe7-57fbb77c06fe"
+      },
+      {
+        "id": 2026071301,
+        "observation_id": 2026071301,
+        "sound_id": 2026071301,
+        "created_at": "2026-07-13 01:00:00",
+        "updated_at": "2026-07-13 01:00:00",
+        "uuid": "9a1f7c2e-2f9f-4f88-b93a-b1a2f0a7f5d3"
+      },
+      {
+        "id": 2026071302,
+        "observation_id": 2026071301,
+        "sound_id": 2026071399,
+        "created_at": "2026-07-13 01:00:00",
+        "updated_at": "2026-07-13 01:00:00",
+        "uuid": "4a4a4f5f-6a3f-45e1-9d5c-2f1b0c3d4e5f"
       }
     ],
     "photos": [
@@ -3112,6 +3166,23 @@
         "file_file_size": 12202,
         "file_updated_at": "2025-01-22 01:00:00",
         "uuid": "933d40cb-fde1-4f50-bfe4-a9dc2f9a34ae",
+        "file_prefix_id": 1,
+        "file_extension_id": 1,
+        "width": 400,
+        "height": 300
+      },
+      {
+        "id": 2026071301,
+        "user_id": 123,
+        "license": 4,
+        "type": "LocalPhoto",
+        "file_content_type": "image/jpeg",
+        "file_file_name": "2026071301.jpeg",
+        "file_file_size": 2040108,
+        "created_at": "2026-07-13 01:00:00",
+        "updated_at": "2026-07-13 01:00:00",
+        "file_updated_at": "2026-07-13 01:00:00",
+        "uuid": "b7f7be06-354c-4f8f-9c33-2d7d21bd90a5",
         "file_prefix_id": 1,
         "file_extension_id": 1,
         "width": 400,

--- a/test/integration/v1/observations.js
+++ b/test/integration/v1/observations.js
@@ -511,7 +511,7 @@ describe( "Observations", ( ) => {
     it( "filters by sounds", function ( done ) {
       request( this.app ).get( "/v1/observations?sounds=true" )
         .expect( res => {
-          expect( res.body.results.length ).to.eq( 3 );
+          expect( res.body.results.length ).to.eq( 4 );
         } ).expect( 200, done );
     } );
 

--- a/test/integration/v2/observations.js
+++ b/test/integration/v2/observations.js
@@ -256,6 +256,50 @@ describe( "Observations", ( ) => {
         .expect( 200, done );
     } );
 
+    it( "returns null photo/sound for observation media referencing deleted media", function ( done ) {
+      obs = _.find( fixtures.elasticsearch.observations.observation, o => (
+        o.description && o.description.match( /referencing deleted media/ )
+      ) );
+      request( this.app ).get( `/v2/observations/${obs.uuid}?fields=all` )
+        .expect( res => {
+          const result = res.body.results[0];
+          // photos contains only photos that still exist
+          expect( result.photos.length ).to.eq( 1 );
+          expect( result.photos[0].id ).to.eq( 2026071301 );
+          // dangling observation_photo is kept with a null photo
+          expect( result.observation_photos.length ).to.eq( 2 );
+          expect( result.observation_photos[0].photo ).to.be.null;
+          expect( result.observation_photos[1].photo.id ).to.eq( 2026071301 );
+          // positions remain contiguous
+          expect( _.map( result.observation_photos, "position" ) ).to.deep.eq( [0, 1] );
+          // dangling observation_sound is kept with a null sound
+          expect( result.sounds.length ).to.eq( 1 );
+          expect( result.observation_sounds.length ).to.eq( 2 );
+          expect( _.filter( result.observation_sounds, os => os.sound === null ).length )
+            .to.eq( 1 );
+          expect( _.filter( result.observation_sounds, os => os.sound !== null )[0].sound.id )
+            .to.eq( 2026071301 );
+        } )
+        .expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+
+    it( "returns 200 via search for observations referencing deleted media", function ( done ) {
+      obs = _.find( fixtures.elasticsearch.observations.observation, o => (
+        o.description && o.description.match( /referencing deleted media/ )
+      ) );
+      // uses the ES search path (integer id param, as in the original bug report)
+      // rather than the show/mget path
+      request( this.app ).get( `/v2/observations?id=${obs.id}&fields=all` )
+        .expect( res => {
+          expect( res.body.total_results ).to.eq( 1 );
+          expect( res.body.results[0].photos.length ).to.eq( 1 );
+          expect( res.body.results[0].observation_photos.length ).to.eq( 2 );
+        } )
+        .expect( "Content-Type", /json/ )
+        .expect( 200, done );
+    } );
+
     // the observations.show endpoint should use the ES mget method to fetch observations for the
     // show endpoint, unless there are additional parameters that will filter the observations
     // returned. This is because the mget method is not affected by the normal ES refresh cycle,

--- a/test/logstasher.js
+++ b/test/logstasher.js
@@ -1,5 +1,6 @@
 const _ = require( "lodash" );
 const { expect } = require( "chai" );
+const sinon = require( "sinon" );
 const Logstasher = require( "../lib/logstasher" );
 
 describe( "Logstasher", ( ) => {
@@ -104,6 +105,33 @@ describe( "Logstasher", ( ) => {
         }
       };
       expect( Logstasher.afterRequestPayload( req ).context ).to.eq( "logContext" );
+    } );
+  } );
+
+  describe( "writeMissingMediaLog", ( ) => {
+    afterEach( ( ) => {
+      sinon.restore( );
+    } );
+
+    it( "does nothing when the log stream is not set", ( ) => {
+      sinon.stub( Logstasher, "logWriteStream" ).returns( undefined );
+      expect( ( ) => Logstasher.writeMissingMediaLog( "photo", 1, 2, 3 ) ).not.to.throw( );
+    } );
+
+    it( "writes a JSON line when the log stream is set", ( ) => {
+      const written = [];
+      sinon.stub( Logstasher, "logWriteStream" ).returns( {
+        write: line => written.push( line )
+      } );
+      Logstasher.writeMissingMediaLog( "photo", 1001, 2002, 3003 );
+      expect( written.length ).to.eq( 1 );
+      const payload = JSON.parse( written[0] );
+      expect( payload.subtype ).to.eq( "MissingMedia" );
+      expect( payload.media_type ).to.eq( "photo" );
+      expect( payload.observation_id ).to.eq( 1001 );
+      expect( payload.media_id ).to.eq( 2002 );
+      expect( payload.join_record_id ).to.eq( 3003 );
+      expect( payload["@timestamp"] ).to.not.be.undefined;
     } );
   } );
 } );

--- a/test/models/observation_preload.js
+++ b/test/models/observation_preload.js
@@ -60,6 +60,18 @@ describe( "ObservationPreload", ( ) => {
       await ObservationPreload.observationPhotos( obs, { } );
       expect( obs[0].photos[0].original_filename ).to.be.undefined;
     } );
+
+    it( "sets photo to null for observation_photos whose photo is missing", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.description && o.description.match( /referencing deleted media/ ) );
+      const obs = [new Observation( observation )];
+      await ObservationPreload.observationPhotos( obs );
+      expect( _.size( obs[0].observation_photos ) ).to.eq( 2 );
+      expect( obs[0].observation_photos[0].photo ).to.be.null;
+      expect( obs[0].observation_photos[1].photo.id ).to.eq( 2026071301 );
+      expect( _.map( obs[0].observation_photos, "position" ) ).to.deep.eq( [0, 1] );
+      expect( _.size( obs[0].photos ) ).to.eq( 1 );
+    } );
   } );
 
   describe( "observationSounds", ( ) => {
@@ -87,6 +99,15 @@ describe( "ObservationPreload", ( ) => {
       const obs = [new Observation( observation )];
       await ObservationPreload.observationSounds( obs, { } );
       expect( obs[0].sounds[0].original_filename ).to.be.undefined;
+    } );
+
+    it( "sets sound to null for observation_sounds whose sound is missing", async ( ) => {
+      const observation = _.find( fixtures.elasticsearch.observations.observation,
+        o => o.description && o.description.match( /referencing deleted media/ ) );
+      const obs = [new Observation( observation )];
+      await ObservationPreload.observationSounds( obs, { } );
+      expect( _.size( obs[0].observation_sounds ) ).to.eq( 2 );
+      expect( _.filter( obs[0].observation_sounds, os => os.sound === null ).length ).to.eq( 1 );
     } );
   } );
 } );


### PR DESCRIPTION
[web-931](https://linear.app/inaturalist/issue/WEB-931) appears to already be incidentally fixed by https://github.com/inaturalist/iNaturalistAPI/commit/696d98ed683b271475ffa44be4f0999964c0c82f#diff-f3bb81688e7bafc360532f1079b633476828de1cd46b6e8368cb15d697f9a844R177 , this PR adds regression specs for the reported bug, and adds some logging to track why observations are missing their photos.