### PR TITLE
fix: update how swaggerUI fetches initial documentation for v2

### DIFF
--- a/lib/inaturalist_api_v2.js
+++ b/lib/inaturalist_api_v2.js
@@ -836,17 +836,32 @@ const InaturalistAPIV2 = class InaturalistAPIV2 {
 
     const swaggerOptions = {
       customSiteTitle: "iNaturalist API",
-      customfavIcon: "/favicon.ico"
+      customfavIcon: "/favicon.ico",
+      swaggerUrl: "/v2/api-docs"
     };
-    const swaggerUIMiddleware = swaggerUi.setup( initializedOpenapi.apiDoc, swaggerOptions );
+
+    const swaggerOptionsWithUnpublished = {
+      ...swaggerOptions,
+      swaggerUrl: "/v2/api-docs?unpublished=true"
+    };
+
+    inaturalistAPIExpressApp.use(
+      "/v2/docs_with_unpublished",
+      swaggerUi.serveFiles( null, swaggerOptionsWithUnpublished ),
+      swaggerUi.setup( null, swaggerOptionsWithUnpublished )
+    );
+
     inaturalistAPIExpressApp.use(
       "/v2/docs",
       ( req, res, next ) => {
-        req.swaggerDoc = InaturalistAPIV2.prepareSwaggerUIApiDoc( req, initializedOpenapi.apiDoc );
+        if ( req.query.unpublished === "true" ) {
+          res.redirect( 302, "/v2/docs_with_unpublished/" );
+          return;
+        }
         next( );
       },
-      swaggerUi.serve,
-      swaggerUIMiddleware
+      swaggerUi.serveFiles( null, swaggerOptions ),
+      swaggerUi.setup( null, swaggerOptions )
     );
   }
 };

--- a/lib/routes_v1.js
+++ b/lib/routes_v1.js
@@ -58,7 +58,16 @@ routesV1.swaggerJSON = ( req, res ) => {
 
 routesV1.robots = ( req, res ) => {
   res.type( "text/plain" );
-  res.send( "User-agent: *\nAllow: /v1/docs\nAllow: /v2/docs\nDisallow: /" );
+  const rules = [
+    "User-agent: *",
+    "Allow: /favicon.ico",
+    "Allow: /v1/docs",
+    "Allow: /v2/docs",
+    "Disallow: /v2/docs?",
+    "Disallow: /*?",
+    "Disallow: /"
+  ];
+  res.send( rules.join( "\n" ) );
 };
 
 module.exports = routesV1;

--- a/openapi/doc.js
+++ b/openapi/doc.js
@@ -28,7 +28,6 @@ fs.readdirSync( "./openapi/schema/request" ).forEach( file => {
 
 const parsedUrl = new URL( config.currentVersionURL );
 const url = `${parsedUrl.protocol}//${parsedUrl.host}/v2`;
-const schemaUrl = `${parsedUrl.protocol}//${parsedUrl.host}/v2/api-docs`;
 const risonUrl = `${url}/observations?fields=(species_guess:!t,user:(login:!t))`;
 
 const apiDoc = {
@@ -40,7 +39,10 @@ const apiDoc = {
     title: "iNaturalist Version 2 API",
     version: "2.2.0",
     description: `## ${url}
-The OpenAPI 3.0 schema definition of this API is available at <${schemaUrl}>.
+[iNaturalist](https://www.inaturalist.org) is a global community of naturalists,
+scientists, and members of the public sharing over a million wildlife sightings
+to teach one another about the natural world while creating high quality citizen
+science data for science and conservation.
 
 These API methods return data in JSON/JSONP and PNG response formats. Visit our
 [developers page](https://www.inaturalist.org/pages/developers) for more

--- a/test/integration/v1/basic.js
+++ b/test/integration/v1/basic.js
@@ -37,9 +37,18 @@ describe( "routes", ( ) => {
 
   describe( "robots", ( ) => {
     it( "renders a robots.txt file", function ( done ) {
+      const rules = [
+        "User-agent: *",
+        "Allow: /favicon.ico",
+        "Allow: /v1/docs",
+        "Allow: /v2/docs",
+        "Disallow: /v2/docs?",
+        "Disallow: /*?",
+        "Disallow: /"
+      ];
       request( this.app ).get( "/robots.txt" )
         .expect( res => {
-          expect( res.text ).to.eq( "User-agent: *\nAllow: /v1/docs\nAllow: /v2/docs\nDisallow: /" );
+          expect( res.text ).to.eq( rules.join( "\n" ) );
         } ).expect( "Content-Type", /plain/ )
         .expect( 200, done );
     } );


### PR DESCRIPTION
* Changes the way swagger documentation is loaded from giving it a schema directly, to having it fetch the schema from a URL
  * This causes swaggerUI to automatically include the schema URL in the documentation, which is why this PR removes that bit of the V2 API description
* Allows bots to access `favicon.ico`